### PR TITLE
[RFC] Add addImport extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ strings which are valid identifiers.
 
   * `jscodeshift -t js-codemod/transforms/unquote-properties.js <file>`
 
+### Included extensions
+
+`imports` helpers for modifying `import` and `require` statements,
+[see docs](extensions/imports/).
+
 ### Recast Options
 
 Options to [recast](https://github.com/benjamn/recast)'s printer can be provided

--- a/extensions/imports/README.md
+++ b/extensions/imports/README.md
@@ -1,0 +1,59 @@
+## Imports extension
+
+A [JSCodeshift](https://github.com/facebook/jscodeshift) extension which
+contains helpers for modifying `import` and `require` statements.
+
+### Setup
+
+Register the extension with jscodeshift.
+
+Usage:
+```javascript
+const imports = require('js-codemod/extensions/imports');
+
+module.exports = function(fileInfo, api) {
+  const {jscodeshift} = api;
+
+  imports.register(jscodeshift, imports.config.CJSBasicRequire);
+
+  // transform here.
+}
+```
+
+Different configs will be needed based on your code style, this extension comes
+with two default configs:
+ - [Basic commonJS style](config/CJSBasicRequireConfig.js), all requires in one
+block.
+ - [Facebook style](config/FBRequireConfig.js), requires are split by the case
+of the module's name.
+
+You can also provide your own custom config.
+
+### API
+
+#### `addImport`
+
+Usage:
+
+```javascript
+const imports = require('js-codemod/extensions/imports');
+
+module.exports = function(fileInfo, api) {
+  const {jscodeshift} = api;
+  const {statement} = jscodeshift.template;
+
+  imports.register(jscodeshift, imports.config.CJSBasicRequire);
+
+  return jscodeshift(file.source)
+    .addImport(statement`
+      const MyRequireItem = require('MyRequireItem');
+    `)
+}
+```
+
+`addImport` accepts any `require` or `import` statement as long as it matches
+one of the config types.
+
+**Note:** This transform cannot be trusted. Whilst this implementation works
+in most cases it can give incorrect whitespace due to limitations in the AST.
+You will need to manually verify the output after running.

--- a/extensions/imports/__tests__/addImportCJSBasicConfig-test.js
+++ b/extensions/imports/__tests__/addImportCJSBasicConfig-test.js
@@ -1,0 +1,288 @@
+'use strict';
+
+jest.autoMockOff();
+
+const jscodeshift = require('jscodeshift');
+const imports = require('../index');
+
+const {statement} = jscodeshift.template;
+
+const DEFAULT_RECAST_CONFIG = {
+  quote: 'single',
+  trailingComma: true,
+  tabWidth: 2,
+};
+
+function test(inputCollection, output) {
+  expect(
+    (inputCollection.toSource(DEFAULT_RECAST_CONFIG) || '').trim()
+  ).toEqual(
+    (output || '').trim()
+  );
+}
+
+// Setup JSCodeShift
+const plugins = imports.createPlugins(imports.config.CJSBasicRequire);
+jscodeshift.registerMethods({
+  addBasicImport: plugins.addImport,
+});
+
+describe('addImportCJSBasicConfig', () => {
+  it('should add to block start', () => {
+    const jfile = jscodeshift(`
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      aaa;
+    `)
+    .addBasicImport(statement`
+      var A0 = require('A0');
+    `);
+
+    test(jfile, `
+      var A0 = require('A0');
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      aaa;
+    `);
+  });
+
+  it('should add to block middle', () => {
+    const jfile = jscodeshift(`
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      aaa;
+    `)
+    .addBasicImport(statement`
+      var A2 = require('A2');
+    `);
+
+    test(jfile, `
+      var A1 = require('A1');
+      var A2 = require('A2');
+      var A3 = require('A3');
+
+      aaa;
+    `);
+  });
+
+  it('should add to block end', () => {
+    const jfile = jscodeshift(`
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      aaa;
+    `)
+    .addBasicImport(statement`
+      var A4 = require('A4');
+    `);
+
+    test(jfile, `
+      var A1 = require('A1');
+      var A3 = require('A3');
+      var A4 = require('A4');
+
+      aaa;
+    `);
+  });
+
+  // TODO: Comments mess with the whitespace output, fix this.
+  // it('should add and maintain comments', () => {
+  //   const jfile = jscodeshift(`
+  //     /* @flow */
+  //
+  //     var A1 = require('A1');
+  //     var A3 = require('A3');
+  //
+  //     aaa;
+  //   `)
+  //   .addBasicImport(statement`
+  //     var A0 = require('A0');
+  //   `);
+  //
+  //   test(jfile, `
+  //     /* @flow */
+  //
+  //     var A0 = require('A0');
+  //     var A1 = require('A1');
+  //     var A3 = require('A3');
+  //
+  //     aaa;
+  //   `);
+  // });
+
+  it('should add to a non first statement', () => {
+    const jfile = jscodeshift(`
+      /* @flow */
+
+      'use strict';
+
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      aaa;
+    `)
+    .addBasicImport(statement`
+      var A0 = require('A0');
+    `);
+
+    test(jfile, `
+      /* @flow */
+
+      'use strict';
+
+      var A0 = require('A0');
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      aaa;
+    `);
+  });
+
+  // TODO: We should check the `node.loc` to see if there is >1 line between
+  // each require, we should only consider the first set of requires that have
+  // no newlines between each other.
+  // it('should not touch any other blocks', () => {
+  //   const jfile = jscodeshift(`
+  //     /* @flow */
+  //
+  //     'use strict';
+  //
+  //     var A1 = require('A1');
+  //     var A3 = require('A3');
+  //
+  //     var A4 = require('A4');
+  //
+  //     aaa;
+  //   `)
+  //   .addBasicImport(statement`
+  //     var A5 = require('A5');
+  //   `);
+  //
+  //   test(jfile, `
+  //     /* @flow */
+  //
+  //     'use strict';
+  //
+  //     var A1 = require('A1');
+  //     var A3 = require('A3');
+  //     var A5 = require('A5');
+  //
+  //     var A4 = require('A4');
+  //
+  //     aaa;
+  //   `);
+  // });
+
+  it('should not touch other any other scopes', () => {
+    const jfile = jscodeshift(`
+      /* @flow */
+
+      'use strict';
+
+      var A1 = require('A1');
+      var A3 = require('A3');
+      if (true) {
+        var A4 = require('A4');
+      }
+
+      aaa;
+    `)
+    .addBasicImport(statement`
+      var A5 = require('A5');
+    `);
+
+    test(jfile, `
+      /* @flow */
+
+      'use strict';
+
+      var A1 = require('A1');
+      var A3 = require('A3');
+      var A5 = require('A5');
+      if (true) {
+        var A4 = require('A4');
+      }
+
+      aaa;
+    `);
+  });
+
+  it('should create block if it doesnt exist', () => {
+    const jfile = jscodeshift(`
+      /* @flow */
+
+      aaa;
+    `)
+    .addBasicImport(statement`
+      var A1 = require('A1');
+    `);
+
+    test(jfile, `
+      /* @flow */
+
+      var A1 = require('A1');
+
+      aaa;
+    `);
+  });
+
+  it('should create block if it doesnt exist (use strict)', () => {
+    const jfile = jscodeshift(`
+      /* @flow */
+
+      'use strict';
+
+      aaa;
+    `)
+    .addBasicImport(statement`
+      var A1 = require('A1');
+    `);
+
+    test(jfile, `
+      /* @flow */
+
+      'use strict';
+
+      var A1 = require('A1');
+
+      aaa;
+    `);
+  });
+
+  it('should add more that one', () => {
+    const jfile = jscodeshift(`
+      /* @flow */
+
+      'use strict';
+
+      var A1 = require('A1');
+
+      aaa;
+    `)
+    .addBasicImport(statement`
+      var A0 = require('A0');
+    `)
+    .addBasicImport(statement`
+      var A2 = require('A2');
+    `)
+    .addBasicImport(statement`
+      var A3 = require('A3');
+    `);
+
+    test(jfile, `
+      /* @flow */
+
+      'use strict';
+
+      var A0 = require('A0');
+      var A1 = require('A1');
+      var A2 = require('A2');
+      var A3 = require('A3');
+
+      aaa;
+    `);
+  });
+});

--- a/extensions/imports/__tests__/addImportFBConfig-test.js
+++ b/extensions/imports/__tests__/addImportFBConfig-test.js
@@ -1,0 +1,193 @@
+'use strict';
+
+jest.autoMockOff();
+
+const jscodeshift = require('jscodeshift');
+const imports = require('../index');
+
+const {statement} = jscodeshift.template;
+
+const DEFAULT_RECAST_CONFIG = {
+  quote: 'single',
+  trailingComma: true,
+  tabWidth: 2,
+};
+
+function test(inputCollection, output) {
+  expect(
+    (inputCollection.toSource(DEFAULT_RECAST_CONFIG) || '').trim()
+  ).toEqual(
+    (output || '').trim()
+  );
+}
+
+// Setup JSCodeShift
+const plugins = imports.createPlugins(imports.config.FBRequire);
+jscodeshift.registerMethods({
+  addFBImport: plugins.addImport,
+});
+
+describe('addImportFBConfig', () => {
+  it('should add to block start large', () => {
+    const jfile = jscodeshift(`
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      var a1 = require('a1');
+
+      aaa;
+    `)
+    .addFBImport(statement`
+      var A0 = require('A0');
+    `);
+
+    test(jfile, `
+      var A0 = require('A0');
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      var a1 = require('a1');
+
+      aaa;
+    `);
+  });
+  it('should add to block start small', () => {
+    const jfile = jscodeshift(`
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      var a1 = require('a1');
+
+      aaa;
+    `)
+    .addFBImport(statement`
+      var a0 = require('a0');
+    `);
+
+    test(jfile, `
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      var a0 = require('a0');
+      var a1 = require('a1');
+
+      aaa;
+    `);
+  });
+
+  it('should add to block middle', () => {
+    const jfile = jscodeshift(`
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      var a1 = require('a1');
+      var a3 = require('a3');
+
+      aaa;
+    `)
+    .addFBImport(statement`
+      var a2 = require('a2');
+    `);
+
+    test(jfile, `
+      var A1 = require('A1');
+      var A3 = require('A3');
+
+      var a1 = require('a1');
+      var a2 = require('a2');
+      var a3 = require('a3');
+
+      aaa;
+    `);
+  });
+
+  it('should create small block if it doesnt exist', () => {
+    const jfile = jscodeshift(`
+      /* @flow */
+
+      'use strict';
+
+      var A1 = require('A1');
+
+      aaa;
+    `)
+    .addFBImport(statement`
+      var a2 = require('a2');
+    `);
+
+    test(jfile, `
+      /* @flow */
+
+      'use strict';
+
+      var A1 = require('A1');
+
+      var a2 = require('a2');
+
+      aaa;
+    `);
+  });
+
+  it('should create large block if it doesnt exist', () => {
+    const jfile = jscodeshift(`
+      /* @flow */
+
+      'use strict';
+
+      var a2 = require('a2');
+
+      aaa;
+    `)
+    .addFBImport(statement`
+      var A1 = require('A1');
+    `);
+
+    test(jfile, `
+      /* @flow */
+
+      'use strict';
+
+      var A1 = require('A1');
+
+      var a2 = require('a2');
+
+      aaa;
+    `);
+  });
+
+  // TODO: Get the whitespace to display correctly in this case.
+  // it('should add more that one', () => {
+  //   const jfile = jscodeshift(`
+  //     /* @flow */
+  //
+  //     'use strict';
+  //
+  //     var A1 = require('A1');
+  //
+  //     aaa;
+  //   `)
+  //   .addFBImport(statement`
+  //     var A0 = require('A0');
+  //   `)
+  //   .addFBImport(statement`
+  //     var a2 = require('a2');
+  //   `)
+  //   .addFBImport(statement`
+  //     var A3 = require('A3');
+  //   `);
+  //
+  //   test(jfile, `
+  //     /* @flow */
+  //
+  //     'use strict';
+  //
+  //     var A0 = require('A0');
+  //     var A1 = require('A1');
+  //     var A3 = require('A3');
+  //
+  //     var a2 = require('a2');
+  //
+  //     aaa;
+  //   `);
+  // });
+});

--- a/extensions/imports/addImport.js
+++ b/extensions/imports/addImport.js
@@ -1,0 +1,136 @@
+const j = require('jscodeshift');
+
+const {statements, statement} = j.template;
+
+function findViaConfigType(type, nodePath) {
+  return j(nodePath)
+    .find(type.searchTerms[0])
+    .filter(p => type.filters.every(filter => filter(p)));
+}
+
+function findInsertTypeIndex(config, requireStatement) {
+  const wrappedRequireStatement = j.program([requireStatement]);
+  for (let i = 0; i < config.length; i++) {
+    if (findViaConfigType(config[i], wrappedRequireStatement).size()) {
+      return i;
+    }
+  }
+
+  throw new Error('No valid config found!');
+}
+
+function findNextInsertIndex(config, root) {
+  for (let i = config.length - 1; i >= 0; i--) {
+    if (findViaConfigType(config[i], root).size()) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+function reprintComment(node) {
+  if (node.type === 'Block') {
+    return j.block(node.value);
+  } else if (node.type === 'Line') {
+    return j.line(node.value);
+  }
+  return node;
+}
+
+function applyCommentsToStatements(nodes, comments) {
+  if (comments) {
+    nodes[0].comments = comments.map(comment => reprintComment(comment));
+  }
+  return nodes;
+}
+
+function reprintNode(node) {
+  if (j.ExpressionStatement.check(node)) {
+    return statement`${node.expression}`;
+  }
+
+  if (j.VariableDeclaration.check(node)) {
+    const declaration = node.declarations[0];
+    return j.variableDeclaration(node.kind, [
+      j.variableDeclarator(declaration.id, declaration.init),
+    ]);
+  }
+
+  if (j.ImportDeclaration.check(node) && node.importKind === 'type') {
+    // TODO: Properly remove new lines from the node.
+    return node;
+  }
+
+  return node;
+}
+
+function addImport(config, root, requireStatement) {
+  const insertTypeIndex = findInsertTypeIndex(config, requireStatement);
+  const currentType = config[insertTypeIndex];
+  const nodesForType = findViaConfigType(currentType, root).paths();
+
+  if (nodesForType.length) {
+    let insertAt = nodesForType.length;
+    for (let i = 0; i < nodesForType.length; i++) {
+      const pos = currentType.comparator(
+        nodesForType[i].value,
+        requireStatement
+      );
+
+      if (pos >= 0) {
+        insertAt = i;
+        break;
+      }
+    }
+
+    if (insertAt === 0) {
+      const nodePath = nodesForType[0];
+      j(nodePath)
+        .replaceWith(applyCommentsToStatements(statements`
+          ${requireStatement};
+          ${reprintNode(nodePath.value)};
+        `, nodePath.value.comments));
+    } else {
+      const nodePath = nodesForType[insertAt - 1];
+      j(nodePath)
+        .replaceWith(applyCommentsToStatements(statements`
+          ${reprintNode(nodePath.value)};
+          ${requireStatement};
+        `, nodePath.value.comments));
+    }
+  } else {
+    const nextFoundConfigTypeIndex = findNextInsertIndex(
+      config,
+      root
+    );
+
+    if (nextFoundConfigTypeIndex > -1) {
+      const requiresForType = findViaConfigType(
+        config[nextFoundConfigTypeIndex],
+        root
+      ).paths();
+
+      if (insertTypeIndex < nextFoundConfigTypeIndex) {
+        j(requiresForType[0])
+          .insertBefore(requireStatement);
+      } else {
+        j(requiresForType[requiresForType.length - 1])
+          .insertAfter(requireStatement);
+      }
+    } else {
+      const firstPath = j(root)
+        .find(j.Program)
+        .get('body')
+        .get(0);
+
+      j(firstPath)
+        .replaceWith(applyCommentsToStatements(statements`
+          ${requireStatement};
+          ${reprintNode(firstPath.value)};
+        `, firstPath.value.comments));
+    }
+  }
+}
+
+module.exports = addImport;

--- a/extensions/imports/config/CJSBasicRequireConfig.js
+++ b/extensions/imports/config/CJSBasicRequireConfig.js
@@ -1,0 +1,20 @@
+const {compareStrings} = require('nuclide-format-js-base/lib/utils/StringUtils');
+const getDeclarationName = require('../utils/getDeclarationName');
+const isGlobal = require('nuclide-format-js-base/lib/utils/isGlobal');
+const isValidRequireDeclaration = require('../utils/isValidRequireDeclaration');
+const jscs = require('jscodeshift');
+
+module.exports = [
+  // Handle general requires, e.g: `require('lowerCase');`
+  {
+    searchTerms: [jscs.VariableDeclaration],
+    filters: [
+      isGlobal,
+      path => isValidRequireDeclaration(path.node),
+    ],
+    comparator: (node1, node2) => compareStrings(
+      getDeclarationName(node1),
+      getDeclarationName(node2)
+    ),
+  },
+];

--- a/extensions/imports/config/FBRequireConfig.js
+++ b/extensions/imports/config/FBRequireConfig.js
@@ -1,0 +1,35 @@
+const {compareStrings, isCapitalized} = require('nuclide-format-js-base/lib/utils/StringUtils');
+const getDeclarationName = require('../utils/getDeclarationName');
+const isGlobal = require('nuclide-format-js-base/lib/utils/isGlobal');
+const isValidRequireDeclaration = require('../utils/isValidRequireDeclaration');
+const jscs = require('jscodeshift');
+
+module.exports = [
+  // Handle UpperCase requires, e.g: `require('UpperCase');`
+  {
+    searchTerms: [jscs.VariableDeclaration],
+    filters: [
+      isGlobal,
+      path => isValidRequireDeclaration(path.node),
+      path => isCapitalized(getDeclarationName(path.node)),
+    ],
+    comparator: (node1, node2) => compareStrings(
+      getDeclarationName(node1),
+      getDeclarationName(node2)
+    ),
+  },
+
+  // Handle lowerCase requires, e.g: `require('lowerCase');`
+  {
+    searchTerms: [jscs.VariableDeclaration],
+    filters: [
+      isGlobal,
+      path => isValidRequireDeclaration(path.node),
+      path => !isCapitalized(getDeclarationName(path.node)),
+    ],
+    comparator: (node1, node2) => compareStrings(
+      getDeclarationName(node1),
+      getDeclarationName(node2)
+    ),
+  },
+];

--- a/extensions/imports/index.js
+++ b/extensions/imports/index.js
@@ -1,0 +1,36 @@
+const addImport = require('./addImport');
+const CJSBasicRequireConfig = require('./config/CJSBasicRequireConfig');
+const FBRequireConfig = require('./config/FBRequireConfig');
+
+module.exports = {
+  register(jscodeshift, config) {
+    const plugins = this.createPlugins(config);
+    jscodeshift.registerMethods(plugins);
+  },
+
+  createPlugins(config) {
+    return {
+
+      /**
+       * Add a new import statement.
+       *
+       * Usage:
+       *
+       *   jscodeshift(file.source)
+       *     .addImport(statement`
+       *       import MyImportItem from './path/to/MyImportItem';
+       *     `);
+       */
+      addImport(importStatement) {
+        return this.forEach(path => {
+          addImport(config, path, importStatement);
+        });
+      },
+    };
+  },
+
+  config: {
+    CJSBasicRequire: CJSBasicRequireConfig,
+    FBRequire: FBRequireConfig,
+  },
+};

--- a/extensions/imports/utils/getDeclarationName.js
+++ b/extensions/imports/utils/getDeclarationName.js
@@ -1,0 +1,19 @@
+const jscs = require('jscodeshift');
+
+function getDeclarationName(node) {
+  var declaration = node.declarations[0];
+  if (jscs.Identifier.check(declaration.id)) {
+    return declaration.id.name;
+  }
+  // Order by the first property name in the object pattern.
+  if (jscs.ObjectPattern.check(declaration.id)) {
+    return declaration.id.properties[0].key.name;
+  }
+  // Order by the first element name in the array pattern.
+  if (jscs.ArrayPattern.check(declaration.id)) {
+    return declaration.id.elements[0].name;
+  }
+  return '';
+}
+
+module.exports = getDeclarationName;

--- a/extensions/imports/utils/isValidRequireDeclaration.js
+++ b/extensions/imports/utils/isValidRequireDeclaration.js
@@ -1,0 +1,25 @@
+const jscs = require('jscodeshift');
+const hasOneRequireDeclaration = require('nuclide-format-js-base/lib/utils/hasOneRequireDeclaration');
+
+function isValidRequireDeclaration(node) {
+  if (!hasOneRequireDeclaration(node)) {
+    return false;
+  }
+  var declaration = node.declarations[0];
+  if (jscs.Identifier.check(declaration.id)) {
+    return true;
+  }
+  if (jscs.ObjectPattern.check(declaration.id)) {
+    return declaration.id.properties.every(
+      prop => prop.shorthand && jscs.Identifier.check(prop.key)
+    );
+  }
+  if (jscs.ArrayPattern.check(declaration.id)) {
+    return declaration.id.elements.every(
+      element => jscs.Identifier.check(element)
+    );
+  }
+  return false;
+}
+
+module.exports = isValidRequireDeclaration;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "eslint": "^1.7.3",
     "fbjs-scripts": "^0.3.0",
     "jest-cli": "^0.6.1",
-    "react-codemod": "https://github.com/reactjs/react-codemod.git#8d84d6def1f653dffe63f25f9b8fc1f4e3f99b68"
+    "react-codemod": "https://github.com/reactjs/react-codemod.git#8d84d6def1f653dffe63f25f9b8fc1f4e3f99b68",
+    "nuclide-format-js-base": "0.0.35"
   },
   "jest": {
     "scriptPreprocessor": "./node_modules/babel-jest",
@@ -32,7 +33,8 @@
       "baseDir": "../../../"
     },
     "testPathDirs": [
-      "test"
+      "test",
+      "extensions"
     ]
   }
 }


### PR DESCRIPTION
The purpose of this is to create a jscodeshift extension that can add requires in a non destructive manner, it doesn't try to have the requires be perfect it just tries to make the best guess at where it should go. I have based a lot of this work from js-format (in fact most of utils is directly copied from here) with the difference in this is non destructive to existing code.

Currently not all the tests pass as i am having some issues with whitespace printing, and i have also not implemented the feature to constraint the require adding to just the first relevant block.

the API looks like this:
```javascript
const plugins = imports.register(jscodeshift, imports.config.CJSBasicRequire);
jscodeshift(file.source)
  .addImport(statement`
    import MyImportItem from './path/to/MyImportItem';
  `)

// Or old school:

jscodeshift(file.source)
  .addImport(statement`
    var MyRequireItem = require('MyRequireItem');
  `);
```

cc @cpojer @fkling @kyldvs