### PR TITLE
Make a safe version of no-vars

### DIFF
--- a/test/no-vars-test.js
+++ b/test/no-vars-test.js
@@ -111,3 +111,25 @@ do {
   var [first2, ...rest2] = foo2;
   rest2 = foo2;
 }();
+
+var myDoubleLet = 10;
+myDoubleLet++;
+var myDoubleLet = 20;
+myDoubleLet++;
+
+var myFakeConstant = 10;
+var myFakeConstant = 20;
+
+if (true) {
+  var blockScopeAbuse = 10;
+}
+console.log(blockScopeAbuse);
+
+console.log(usedTooEarly);
+var usedTooEarly = 10;
+
+for (var dangerousLoop = 0; dangerousLoop < 10; dangerousLoop++) {
+  setTimeout(() => {
+    console.log(dangerousLoop);
+  }, 100);
+}

--- a/test/no-vars-test.js
+++ b/test/no-vars-test.js
@@ -133,3 +133,9 @@ for (var dangerousLoop = 0; dangerousLoop < 10; dangerousLoop++) {
     console.log(dangerousLoop);
   }, 100);
 }
+
+console.log(desctructuringAlias);
+var {desctructuringToBeAliased: desctructuringAlias} = whatever();
+
+var {descructuringB} = whatever();
+var {descructuringB} = whateverElse();

--- a/test/no-vars-test.output.js
+++ b/test/no-vars-test.output.js
@@ -2,11 +2,11 @@
 
 const module = require('module');
 
-for (let i = 0; i < 10; i++) {
+for (var i = 0; i < 10; i++) {
 
 }
 
-for (let i = 0; i < 10; i++) {
+for (i = 0; i < 10; i++) {
 }
 
 let letItBe;
@@ -56,8 +56,7 @@ do {
 })();
 
 (() => {
-  let a = 1;
-  const b = 2, c = 3;
+  let a = 1, b = 2, c = 3;
 
   a++;
 
@@ -112,3 +111,25 @@ do {
   let [first2, ...rest2] = foo2;
   rest2 = foo2;
 })();
+
+var myDoubleLet = 10;
+myDoubleLet++;
+var myDoubleLet = 20;
+myDoubleLet++;
+
+var myFakeConstant = 10;
+var myFakeConstant = 20;
+
+if (true) {
+  var blockScopeAbuse = 10;
+}
+console.log(blockScopeAbuse);
+
+console.log(usedTooEarly);
+var usedTooEarly = 10;
+
+for (var dangerousLoop = 0; dangerousLoop < 10; dangerousLoop++) {
+  setTimeout(() => {
+    console.log(dangerousLoop);
+  }, 100);
+}

--- a/test/no-vars-test.output.js
+++ b/test/no-vars-test.output.js
@@ -133,3 +133,9 @@ for (var dangerousLoop = 0; dangerousLoop < 10; dangerousLoop++) {
     console.log(dangerousLoop);
   }, 100);
 }
+
+console.log(desctructuringAlias);
+var {desctructuringToBeAliased: desctructuringAlias} = whatever();
+
+var {descructuringB} = whatever();
+var {descructuringB} = whateverElse();


### PR DESCRIPTION
This is a first pass at making no-vars safe.  I believe it handles
pretty much all the cases where `var` behaves oddly, by just leaving
them as `var`.  I didn't make it separate out `let` and `const` when
they were mixed in a single `var` declaration, but I can add that in if
desired.  I also didn't implement the behaviour of converting multiple
for loops that reuse a variable into `let` as it seemed highly complex
to get right.  I've added some TODOs for that though.