### PR TITLE
Make the imports extension its own package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ strings which are valid identifiers.
 
 ### Included extensions
 
-`imports` helpers for modifying `import` and `require` statements,
+`jscodeshift-imports` helpers for modifying `import` and `require` statements,
 [see docs](extensions/imports/).
 
 ### Recast Options

--- a/extensions/imports/README.md
+++ b/extensions/imports/README.md
@@ -1,22 +1,22 @@
-## Imports extension
+## jscodeshift-imports extension
 
 A [JSCodeshift](https://github.com/facebook/jscodeshift) extension which
 contains helpers for modifying `import` and `require` statements.
 
 ### Setup
 
-Register the extension with jscodeshift.
+Install extension: `npm install jscodeshift-imports`.
 
-Usage:
+Register the extension with jscodeshift:
 ```javascript
-const imports = require('js-codemod/extensions/imports');
+const imports = require('jscodeshift-imports');
 
 module.exports = function(fileInfo, api) {
   const {jscodeshift} = api;
 
   imports.register(jscodeshift, imports.config.CJSBasicRequire);
 
-  // transform here.
+  // Your transform here.
 }
 ```
 
@@ -33,10 +33,13 @@ You can also provide your own custom config.
 
 #### `addImport`
 
-Usage:
+This helper allows you to insert require statements into the most appropriate
+place within a file, it does this in a non destructive way so your codemod will
+change as little in the file as it can.
 
+Usage:
 ```javascript
-const imports = require('js-codemod/extensions/imports');
+const imports = require('jscodeshift-imports');
 
 module.exports = function(fileInfo, api) {
   const {jscodeshift} = api;
@@ -48,6 +51,7 @@ module.exports = function(fileInfo, api) {
     .addImport(statement`
       const MyRequireItem = require('MyRequireItem');
     `)
+    .toSource();
 }
 ```
 

--- a/extensions/imports/package.json
+++ b/extensions/imports/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "jscodeshift-imports",
+  "author": "Pieter Vanderwerff",
+  "version": "1.0.0",
+  "description": "A JSCodeshift extension with helpers for modifying `import` and `require` statements.",
+  "license": "MIT",
+  "repository": "https://github.com/cpojer/js-codemod/tree/master/extensions/imports",
+  "keywords": [
+    "codemod",
+    "recast",
+    "jscodeshift",
+    "require",
+    "import"
+  ],
+  "dependencies": {
+    "jscodeshift": "^0.3.0",
+    "nuclide-format-js-base": "^0.0.35"
+  }
+}


### PR DESCRIPTION
I have called the extension `jscodeshift-imports` since it's specific to `jscodeshift`, or should it be `js-codemod-imports` since it's in that repo??

This adds the `package.json` + cleans up the docs a little.