### PR TITLE
Teach invalid-requires to better handle comments

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
 node_modules
-test/invalid-requires-test.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+test/invalid-requires-test.js

--- a/test/__tests__/invalid-requires-test.js
+++ b/test/__tests__/invalid-requires-test.js
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+describe('invalid-requires', () => {
+
+  it('transforms correctly', () => {
+    test('invalid-requires', 'invalid-requires-test');
+  });
+
+});

--- a/test/invalid-requires-test.js
+++ b/test/invalid-requires-test.js
@@ -1,2 +1,4 @@
+/* eslint-disable one-var */
 var foo = require('foo'),
+  // A comment
   bar = require('bar');

--- a/test/invalid-requires-test.js
+++ b/test/invalid-requires-test.js
@@ -1,0 +1,2 @@
+var foo = require('foo'),
+  bar = require('bar');

--- a/test/invalid-requires-test.output.js
+++ b/test/invalid-requires-test.output.js
@@ -1,0 +1,2 @@
+var foo = require('foo');
+var bar = require('bar');

--- a/test/invalid-requires-test.output.js
+++ b/test/invalid-requires-test.output.js
@@ -1,2 +1,5 @@
+/* eslint-disable one-var */
 var foo = require('foo');
+
+// A comment
 var bar = require('bar');

--- a/transforms/invalid-requires.js
+++ b/transforms/invalid-requires.js
@@ -1,25 +1,31 @@
 module.exports = function(file, api) {
-  const j = api.jscodeshift;
-  const S = new Set();
-  const root = j(file.source)
-    .find(j.CallExpression, {callee: {name: 'require'}})
-  .filter(p => (
-      p.parent.value.type == 'VariableDeclarator' &&
-      p.parent.parent.value.declarations.length != 1
+  const jscodeshift = api.jscodeshift;
+  const requireStatements = new Set();
+
+  const root = jscodeshift(file.source)
+    .find(jscodeshift.CallExpression, {callee: {name: 'require'}})
+    .filter(requireStatement => (
+      requireStatement.parent.value.type == 'VariableDeclarator' &&
+      requireStatement.parent.parent.value.declarations.length != 1
     ))
-    .forEach(p => {
-      S.add(p.parent.parent);
+    .forEach(requireStatement => {
+      requireStatements.add(requireStatement.parent.parent);
     });
-  S.forEach(p => {
-    j(p).replaceWith(p.value.declarations.map(
-      (declaration, i) => {
-        var d = j.variableDeclaration('var', [declaration]);
+
+  requireStatements.forEach(requireStatement => {
+    jscodeshift(requireStatement)
+      .replaceWith(requireStatement.value.declarations.map((declaration, i) => {
+        var variableDeclaration =
+          jscodeshift.variableDeclaration('var', [declaration]);
+
         if (i == 0) {
-          d.comments = p.value.comments;
+          variableDeclaration.comments = requireStatement.value.comments;
         }
-        return d;
+
+        return variableDeclaration;
       }
     ));
   });
-  return S.size ? root.toSource({quote: 'single'}) : null;
+
+  return requireStatements.size ? root.toSource({quote: 'single'}) : null;
 };

--- a/transforms/invalid-requires.js
+++ b/transforms/invalid-requires.js
@@ -20,6 +20,9 @@ module.exports = function(file, api) {
 
         if (i == 0) {
           variableDeclaration.comments = requireStatement.value.comments;
+        } else if (declaration.comments) {
+          variableDeclaration.comments = declaration.comments;
+          declaration.comments = null;
         }
 
         return variableDeclaration;


### PR DESCRIPTION
When converting a require block like:

```js
var foo = require('foo'),
  // A comment
  bar = require('bar');
```

this transform was producing the unusual output:

```js
var foo = require('foo');

var // A comment
bar = require('bar');
```

This commit fixes this by moving the comment from the require statement
declaration up to the variable declaration. It now produces the following:


```js
var foo = require('foo');

// A comment
var bar = require('bar');
```