### PR TITLE
Preserve kind of variable declaration in invalid-requires

### DIFF
--- a/test/invalid-requires-test.js
+++ b/test/invalid-requires-test.js
@@ -2,3 +2,5 @@
 var foo = require('foo'),
   // A comment
   bar = require('bar');
+const baz = require('baz'),
+  fiz = require('fiz');

--- a/test/invalid-requires-test.output.js
+++ b/test/invalid-requires-test.output.js
@@ -3,3 +3,6 @@ var foo = require('foo');
 
 // A comment
 var bar = require('bar');
+
+const baz = require('baz');
+const fiz = require('fiz');

--- a/transforms/invalid-requires.js
+++ b/transforms/invalid-requires.js
@@ -15,8 +15,9 @@ module.exports = function(file, api) {
   requireStatements.forEach(requireStatement => {
     jscodeshift(requireStatement)
       .replaceWith(requireStatement.value.declarations.map((declaration, i) => {
-        var variableDeclaration =
-          jscodeshift.variableDeclaration('var', [declaration]);
+        const kind = requireStatement.value.kind; // e.g. var or const
+        const variableDeclaration =
+          jscodeshift.variableDeclaration(kind, [declaration]);
 
         if (i == 0) {
           variableDeclaration.comments = requireStatement.value.comments;


### PR DESCRIPTION
I noticed that this was always using `var` even if `const` was used
before the transform. This commit aims to preserve the kind that was
used.