### PR TITLE
Add unchain-variables transform

### DIFF
--- a/test/__tests__/unchain-variables-test.js
+++ b/test/__tests__/unchain-variables-test.js
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+describe('unchain-variables', () => {
+
+  it('transforms correctly', () => {
+    test('unchain-variables', 'unchain-variables-test');
+  });
+
+});

--- a/test/unchain-variables-test.js
+++ b/test/unchain-variables-test.js
@@ -1,0 +1,9 @@
+/* eslint-disable one-var, prefer-const */
+var foo = true,
+  // A comment
+  bar = false;
+const baz = 1,
+  fiz = '2';
+let buzz = 3.3,
+  biz = {};
+var hello, hi;

--- a/test/unchain-variables-test.js
+++ b/test/unchain-variables-test.js
@@ -6,4 +6,5 @@ const baz = 1,
   fiz = '2';
 let buzz = 3.3,
   biz = {};
-var hello, hi;
+var hello, ohai = function ohai() {}, hi;
+var Neil, deGrasse, Tyson;

--- a/test/unchain-variables-test.output.js
+++ b/test/unchain-variables-test.output.js
@@ -1,0 +1,12 @@
+/* eslint-disable one-var, prefer-const */
+var foo = true;
+
+// A comment
+var bar = false;
+
+const baz = 1;
+const fiz = '2';
+let buzz = 3.3;
+let biz = {};
+var hello;
+var hi;

--- a/test/unchain-variables-test.output.js
+++ b/test/unchain-variables-test.output.js
@@ -9,4 +9,8 @@ const fiz = '2';
 let buzz = 3.3;
 let biz = {};
 var hello;
+var ohai = function ohai() {};
 var hi;
+var Neil;
+var deGrasse;
+var Tyson;

--- a/transforms/invalid-requires.js
+++ b/transforms/invalid-requires.js
@@ -1,5 +1,6 @@
-module.exports = function(file, api) {
+module.exports = function(file, api, options) {
   const jscodeshift = api.jscodeshift;
+  const printOptions = options.printOptions || {quote: 'single'};
   const requireStatements = new Set();
 
   const root = jscodeshift(file.source)
@@ -31,5 +32,5 @@ module.exports = function(file, api) {
     ));
   });
 
-  return requireStatements.size ? root.toSource({quote: 'single'}) : null;
+  return requireStatements.size ? root.toSource(printOptions) : null;
 };

--- a/transforms/outline-require.js
+++ b/transforms/outline-require.js
@@ -1,7 +1,9 @@
-module.exports = function(file, api) {
+module.exports = function(file, api, options) {
   if (file.path.indexOf('/__tests__/') == -1) {
     return null;
   }
+
+  const printOptions = options.printOptions || {quote: 'single'};
 
   const REQUIRE_CALL = {
     type: 'CallExpression',
@@ -216,5 +218,5 @@ module.exports = function(file, api) {
 
   body[0].comments = firstComment;
 
-  return root.toSource({quote: 'single'});
+  return root.toSource(printOptions);
 };

--- a/transforms/unchain-variables.js
+++ b/transforms/unchain-variables.js
@@ -1,0 +1,35 @@
+/**
+ * Unchains chained variable declarations.
+ */
+module.exports = function(file, api) {
+  const jscodeshift = api.jscodeshift;
+
+  const chainedDeclarations = jscodeshift(file.source)
+    .find(jscodeshift.VariableDeclaration)
+    .filter(variableDeclaration => (
+      variableDeclaration.value.declarations.length > 1
+    ));
+
+  chainedDeclarations.forEach(chainedDeclaration => {
+    const kind = chainedDeclaration.value.kind; // e.g. const, let, or var
+
+    jscodeshift(chainedDeclaration)
+      .replaceWith(chainedDeclaration.value.declarations.map((declaration, i) => {
+        const unchainedDeclaration =
+          jscodeshift.variableDeclaration(kind, [declaration]);
+
+        if (i === 0) {
+          unchainedDeclaration.comments = chainedDeclaration.value.comments;
+        } else if (declaration.comments) {
+          unchainedDeclaration.comments = declaration.comments;
+          declaration.comments = null;
+        }
+
+        return unchainedDeclaration;
+      }));
+  });
+
+  return chainedDeclarations.size
+    ? chainedDeclarations.toSource({quote: 'single'})
+    : null;
+};

--- a/transforms/unchain-variables.js
+++ b/transforms/unchain-variables.js
@@ -1,8 +1,9 @@
 /**
  * Unchains chained variable declarations.
  */
-module.exports = function(file, api) {
+module.exports = function(file, api, options) {
   const jscodeshift = api.jscodeshift;
+  const printOptions = options.printOptions || {quote: 'single'};
 
   const chainedDeclarations = jscodeshift(file.source)
     .find(jscodeshift.VariableDeclaration)
@@ -30,6 +31,6 @@ module.exports = function(file, api) {
   });
 
   return chainedDeclarations.size
-    ? chainedDeclarations.toSource({quote: 'single'})
+    ? chainedDeclarations.toSource(printOptions)
     : null;
 };


### PR DESCRIPTION
This transform will unchain chained variable declarations. Converting
code like:

```js
var foo, bar;
```

to:

```js
var foo;
var bar;
```