### PR TITLE
Teach no-vars about array destructuring with ignored values

### DIFF
--- a/test/no-vars-test.js
+++ b/test/no-vars-test.js
@@ -140,6 +140,8 @@ var {destructuringToBeAliased: destructuringAlias} = whatever();
 var {destructuringB} = whatever();
 var {destructuringB} = whateverElse();
 
+var [, destructuringC, destructuringD] = whatever();
+
 setSetByHoistedFunction();
 var setByHoistedFunction;
 function setSetByHoistedFunction() {

--- a/test/no-vars-test.js
+++ b/test/no-vars-test.js
@@ -134,11 +134,11 @@ for (var dangerousLoop = 0; dangerousLoop < 10; dangerousLoop++) {
   }, 100);
 }
 
-console.log(desctructuringAlias);
-var {desctructuringToBeAliased: desctructuringAlias} = whatever();
+console.log(destructuringAlias);
+var {destructuringToBeAliased: destructuringAlias} = whatever();
 
-var {descructuringB} = whatever();
-var {descructuringB} = whateverElse();
+var {destructuringB} = whatever();
+var {destructuringB} = whateverElse();
 
 setSetByHoistedFunction();
 var setByHoistedFunction;

--- a/test/no-vars-test.output.js
+++ b/test/no-vars-test.output.js
@@ -140,6 +140,8 @@ var {destructuringToBeAliased: destructuringAlias} = whatever();
 var {destructuringB} = whatever();
 var {destructuringB} = whateverElse();
 
+const [, destructuringC, destructuringD] = whatever();
+
 setSetByHoistedFunction();
 var setByHoistedFunction;
 function setSetByHoistedFunction() {

--- a/test/no-vars-test.output.js
+++ b/test/no-vars-test.output.js
@@ -134,11 +134,11 @@ for (var dangerousLoop = 0; dangerousLoop < 10; dangerousLoop++) {
   }, 100);
 }
 
-console.log(desctructuringAlias);
-var {desctructuringToBeAliased: desctructuringAlias} = whatever();
+console.log(destructuringAlias);
+var {destructuringToBeAliased: destructuringAlias} = whatever();
 
-var {descructuringB} = whatever();
-var {descructuringB} = whateverElse();
+var {destructuringB} = whatever();
+var {destructuringB} = whateverElse();
 
 setSetByHoistedFunction();
 var setByHoistedFunction;

--- a/transforms/no-vars.js
+++ b/transforms/no-vars.js
@@ -38,7 +38,15 @@ export default function(file, api) {
       );
     } else if (id.type === 'ArrayPattern') {
       return id.elements.map(
-        e => (e.type === 'RestElement' ? e.argument.name : e.name)
+        e => {
+          if (!e) {
+            return null;
+          }
+          if (e.type === 'RestElement') {
+            return e.argument.name;
+          }
+          return e.name;
+        }
       );
     } else if (id.type === 'Identifier') {
       return [id.name];
@@ -199,9 +207,13 @@ export default function(file, api) {
               (d.type === 'SpreadProperty' ? d.argument.name : d.value.name) === n.value.left.name
             );
           } else if (declarator.id.type === 'ArrayPattern') {
-            return declarator.id.elements.some(d =>
-              (d.type === 'RestElement' ? d.argument.name : d.name) === n.value.left.name
-            );
+            return declarator.id.elements.some(d => {
+              if (!d) {
+                return false;
+              }
+              const name = d.type === 'RestElement' ? d.argument.name : d.name;
+              return name === n.value.left.name;
+            });
           }
 
           if (n.value.left.type === 'ObjectPattern') {
@@ -228,9 +240,13 @@ export default function(file, api) {
               (d.type === 'SpreadProperty' ? d.argument.name : d.value.name) === n.value.argument.name
             );
           } else if (declarator.id.type === 'ArrayPattern') {
-            return declarator.id.elements.some(
-              e => (e.type === 'RestElement' ? e.argument.name : e.name) === n.value.argument.name
-            );
+            return declarator.id.elements.some(e => {
+              if (!e) {
+                return false;
+              }
+              const name = e.type === 'RestElement' ? e.argument.name : e.name;
+              return name === n.value.argument.name;
+            });
           }
 
           return declarator.id.name === n.value.argument.name;


### PR DESCRIPTION
While running this on Airbnb code, I ran into the following error:

> TypeError: Cannot read property 'type' of null

Which seemed to happen when encountering array destructuring with
ignored values, like:

```js
var [, foo, bar] = baz;
```

I fixed this by guarding against this case in a few places.

While I was at it, I also fixed some typos that I happened to notice.