### PR TITLE
Skip ForStatements when unchaining variables

### DIFF
--- a/test/unchain-variables-test.js
+++ b/test/unchain-variables-test.js
@@ -8,3 +8,6 @@ let buzz = 3.3,
   biz = {};
 var hello, ohai = function ohai() {}, hi;
 var Neil, deGrasse, Tyson;
+for (var i = 0, j = 10; i < j; i++, j--) {
+  console.log(i, j);
+}

--- a/test/unchain-variables-test.output.js
+++ b/test/unchain-variables-test.output.js
@@ -14,3 +14,6 @@ var hi;
 var Neil;
 var deGrasse;
 var Tyson;
+for (var i = 0, j = 10; i < j; i++, j--) {
+  console.log(i, j);
+}

--- a/transforms/unchain-variables.js
+++ b/transforms/unchain-variables.js
@@ -9,6 +9,9 @@ module.exports = function(file, api, options) {
     .find(jscodeshift.VariableDeclaration)
     .filter(variableDeclaration => (
       variableDeclaration.value.declarations.length > 1
+    ))
+    .filter(variableDeclaration => (
+      variableDeclaration.parent.value.type !== 'ForStatement'
     ));
 
   chainedDeclarations.forEach(chainedDeclaration => {


### PR DESCRIPTION
When encountering a ForStatement, this would output an error complaining
that it was unable to replace the path. To prevent this, I added a
filter.