### PR TITLE
Add dangling commas transform

### DIFF
--- a/test/__tests__/trailing-commas-test.js
+++ b/test/__tests__/trailing-commas-test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('dangling-commas', () => {
+  it('transforms correctly', () => {
+    test('dangling-commas', 'dangling-commas-test');
+  });
+});

--- a/test/trailing-commas-test.js
+++ b/test/trailing-commas-test.js
@@ -1,0 +1,16 @@
+/* eslint-disable comma-dangle */
+const object = {
+  hello: 'hello',
+  allo: 'allo',
+  hola: 'hola'
+};
+
+const object2 = {hello: 'hello', allo: 'allo', hola: 'hola'};
+
+const array = [
+  'hello',
+  'allo',
+  'hola'
+];
+
+const array2 = ['hello', 'allo', 'hola'];

--- a/test/trailing-commas-test.output.js
+++ b/test/trailing-commas-test.output.js
@@ -1,0 +1,16 @@
+/* eslint-disable comma-dangle */
+const object = {
+  hello: 'hello',
+  allo: 'allo',
+  hola: 'hola',
+};
+
+const object2 = {hello: 'hello', allo: 'allo', hola: 'hola'};
+
+const array = [
+  'hello',
+  'allo',
+  'hola',
+];
+
+const array2 = ['hello', 'allo', 'hola'];

--- a/transforms/trailing-commas.js
+++ b/transforms/trailing-commas.js
@@ -1,0 +1,44 @@
+/**
+ * Adds trailing commas to every object litteral and array.
+ */
+export default function(file, api, options) {
+  const j = api.jscodeshift;
+
+  const objectHasNoTrailingComma = ({node}) => {
+    // Only transform objects that are on multiple lines.
+    if (node.properties.length === 0 || node.loc.start.line === node.loc.end.line) {
+      return false;
+    }
+    const lastProp = node.properties[node.properties.length - 1];
+    return file.source.charAt(lastProp.end) !== ',';
+  };
+
+  const arrayHasNoTrailingComma = ({node}) => {
+    // Only transform arrays that are on multiple lines.
+    if (node.elements.length === 0 || node.loc.start.line === node.loc.end.line) {
+      return false;
+    }
+    const lastEle = node.elements[node.elements.length - 1];
+    return file.source.charAt(lastEle.end) !== ',';
+  };
+
+  const forceReprint = ({node}) => {
+    node.original = null;
+  };
+
+  const root = j(file.source);
+  root
+    .find(j.ObjectExpression)
+    .filter(objectHasNoTrailingComma)
+    .forEach(forceReprint);
+  root
+    .find(j.ArrayExpression)
+    .filter(arrayHasNoTrailingComma)
+    .forEach(forceReprint);
+
+  return root.toSource({
+    ...options.printOptions,
+    trailingComma: true,
+    wrapColumn: 0, // Makes sure we write each values on a separate line.
+  });
+}


### PR DESCRIPTION
Transform to add dangling commas to allow enabling eslint dangling-commas always-multiline rule. It formats only arrays and objects that don't already have a dangling comma to keep changes as minimal as possible.

What I did is to find all the object/arrays that don't have a trailing comma and then add a random key to them so they are modified. Then in a second pass I remove the added keys and format using recast trailingComma option.

The end goal here would be to run that the on react-native codebase to enable stricter eslint rules without having to manually fix the 1k+ warnings it will generate :)

Tested against the react-native codebase pretty succesfully. The only thing it doesn't support that eslint complains about is trailing commas in destructuring. It should be pretty easy to add support.