### PR TITLE
Fix trailing-commas test

### DIFF
--- a/test/__tests__/trailing-commas-test.js
+++ b/test/__tests__/trailing-commas-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-describe('dangling-commas', () => {
+describe('trailing-commas', () => {
   it('transforms correctly', () => {
-    test('dangling-commas', 'dangling-commas-test');
+    test('trailing-commas', 'trailing-commas-test');
   });
 });


### PR DESCRIPTION
This test file was referencing dangling-commas and dangling-commas-test,
which don't exist.