### PR TITLE
Node compatibility for `imports` extenision.

### DIFF
--- a/extensions/imports/__tests__/addImportCJSBasicConfig-test.js
+++ b/extensions/imports/__tests__/addImportCJSBasicConfig-test.js
@@ -5,7 +5,7 @@ jest.autoMockOff();
 const jscodeshift = require('jscodeshift');
 const imports = require('../index');
 
-const {statement} = jscodeshift.template;
+const statement = jscodeshift.template.statement;
 
 const DEFAULT_RECAST_CONFIG = {
   quote: 'single',

--- a/extensions/imports/__tests__/addImportFBConfig-test.js
+++ b/extensions/imports/__tests__/addImportFBConfig-test.js
@@ -5,7 +5,7 @@ jest.autoMockOff();
 const jscodeshift = require('jscodeshift');
 const imports = require('../index');
 
-const {statement} = jscodeshift.template;
+const statement = jscodeshift.template.statement;
 
 const DEFAULT_RECAST_CONFIG = {
   quote: 'single',

--- a/extensions/imports/addImport.js
+++ b/extensions/imports/addImport.js
@@ -1,6 +1,9 @@
+'use strict';
+
 const j = require('jscodeshift');
 
-const {statements, statement} = j.template;
+const statements = j.template.statements;
+const statement = j.template.statement;
 
 function findViaConfigType(type, nodePath) {
   return j(nodePath)

--- a/extensions/imports/config/CJSBasicRequireConfig.js
+++ b/extensions/imports/config/CJSBasicRequireConfig.js
@@ -1,4 +1,6 @@
-const {compareStrings} = require('nuclide-format-js-base/lib/utils/StringUtils');
+'use strict';
+
+const StringUtils = require('nuclide-format-js-base/lib/utils/StringUtils');
 const getDeclarationName = require('../utils/getDeclarationName');
 const isGlobal = require('nuclide-format-js-base/lib/utils/isGlobal');
 const isValidRequireDeclaration = require('../utils/isValidRequireDeclaration');
@@ -12,7 +14,7 @@ module.exports = [
       isGlobal,
       path => isValidRequireDeclaration(path.node),
     ],
-    comparator: (node1, node2) => compareStrings(
+    comparator: (node1, node2) => StringUtils.compareStrings(
       getDeclarationName(node1),
       getDeclarationName(node2)
     ),

--- a/extensions/imports/config/FBRequireConfig.js
+++ b/extensions/imports/config/FBRequireConfig.js
@@ -1,4 +1,6 @@
-const {compareStrings, isCapitalized} = require('nuclide-format-js-base/lib/utils/StringUtils');
+'use strict';
+
+const StringUtils = require('nuclide-format-js-base/lib/utils/StringUtils');
 const getDeclarationName = require('../utils/getDeclarationName');
 const isGlobal = require('nuclide-format-js-base/lib/utils/isGlobal');
 const isValidRequireDeclaration = require('../utils/isValidRequireDeclaration');
@@ -11,9 +13,9 @@ module.exports = [
     filters: [
       isGlobal,
       path => isValidRequireDeclaration(path.node),
-      path => isCapitalized(getDeclarationName(path.node)),
+      path => StringUtils.isCapitalized(getDeclarationName(path.node)),
     ],
-    comparator: (node1, node2) => compareStrings(
+    comparator: (node1, node2) => StringUtils.compareStrings(
       getDeclarationName(node1),
       getDeclarationName(node2)
     ),
@@ -25,9 +27,9 @@ module.exports = [
     filters: [
       isGlobal,
       path => isValidRequireDeclaration(path.node),
-      path => !isCapitalized(getDeclarationName(path.node)),
+      path => !StringUtils.isCapitalized(getDeclarationName(path.node)),
     ],
-    comparator: (node1, node2) => compareStrings(
+    comparator: (node1, node2) => StringUtils.compareStrings(
       getDeclarationName(node1),
       getDeclarationName(node2)
     ),

--- a/extensions/imports/index.js
+++ b/extensions/imports/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const addImport = require('./addImport');
 const CJSBasicRequireConfig = require('./config/CJSBasicRequireConfig');
 const FBRequireConfig = require('./config/FBRequireConfig');

--- a/extensions/imports/utils/getDeclarationName.js
+++ b/extensions/imports/utils/getDeclarationName.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const jscs = require('jscodeshift');
 
 function getDeclarationName(node) {

--- a/extensions/imports/utils/isValidRequireDeclaration.js
+++ b/extensions/imports/utils/isValidRequireDeclaration.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const jscs = require('jscodeshift');
 const hasOneRequireDeclaration = require('nuclide-format-js-base/lib/utils/hasOneRequireDeclaration');
 


### PR DESCRIPTION
Changes:
- remove object deconstruction
- add 'use strict'

Tested by removing the babel preprocessor from jest and running the tests :)