### PR TITLE
Fix trailing-commas transform with objects in function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Areas of improvement:
   literal. It would be nice to perserve the original--whether it be a unicode
   escape sequence or a unicode character.
 
+#### `trailing-commas`
+
+Adds trailing commas to array and object literals.
+
+```sh
+jscodeshift -t js-codemod/transforms/trailing-commas.js <file>
+```
+
 #### `unquote-properties`
 
 Removes quotes from object properties whose keys are strings which are valid

--- a/test/trailing-commas-test.js
+++ b/test/trailing-commas-test.js
@@ -14,3 +14,7 @@ const array = [
 ];
 
 const array2 = ['hello', 'allo', 'hola'];
+
+test({
+  test: 'test'
+});

--- a/test/trailing-commas-test.output.js
+++ b/test/trailing-commas-test.output.js
@@ -14,3 +14,7 @@ const array = [
 ];
 
 const array2 = ['hello', 'allo', 'hola'];
+
+test({
+  test: 'test',
+});

--- a/transforms/trailing-commas.js
+++ b/transforms/trailing-commas.js
@@ -39,6 +39,6 @@ export default function(file, api, options) {
   return root.toSource({
     ...options.printOptions,
     trailingComma: true,
-    wrapColumn: 0, // Makes sure we write each values on a separate line.
+    wrapColumn: 1, // Makes sure we write each values on a separate line.
   });
 }


### PR DESCRIPTION
Simply setting the wrapColumn formatting option to 1 instead of 0 makes it not add new lines everywhere.

Also adds the transform to the readme.

Fixes #27

cc @lencioni @cpojer 