### PR TITLE
move some dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,15 +17,17 @@
     "recast"
   ],
   "dependencies": {
+    "jscodeshift": "^0.3.20",
+    "nuclide-format-js-base": "0.0.35"
+  },
+  "devDependencies": {
     "babel-eslint": "^5.0.0",
     "babel-jest": "^9.0.2",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "eslint": "^1.7.3",
     "fbjs-scripts": "^0.5.0",
-    "jest-cli": "^11.0.2",
-    "jscodeshift": "^0.3.20",
-    "nuclide-format-js-base": "0.0.35"
+    "jest-cli": "^11.0.2"
   },
   "jest": {
     "automock": false,


### PR DESCRIPTION
I moved the dependencies that are only used for linting or testing to the devDependencies section of the package.json. This is so that if this is included as a dependency of something else it does not bring in any excess baggage!