### PR TITLE
Imports Extension: Use the jscodeshift `use` api.

### DIFF
--- a/extensions/imports/README.md
+++ b/extensions/imports/README.md
@@ -14,7 +14,7 @@ const imports = require('jscodeshift-imports');
 module.exports = function(fileInfo, api) {
   const {jscodeshift} = api;
 
-  imports.register(jscodeshift, imports.config.CJSBasicRequire);
+  jscodeshift.use(imports(imports.config.CJSBasicRequire));
 
   // Your transform here.
 }
@@ -45,7 +45,7 @@ module.exports = function(fileInfo, api) {
   const {jscodeshift} = api;
   const {statement} = jscodeshift.template;
 
-  imports.register(jscodeshift, imports.config.CJSBasicRequire);
+  jscodeshift.use(imports(imports.config.CJSBasicRequire));
 
   return jscodeshift(file.source)
     .addImport(statement`

--- a/extensions/imports/__tests__/addImportCJSBasicConfig-test.js
+++ b/extensions/imports/__tests__/addImportCJSBasicConfig-test.js
@@ -22,10 +22,7 @@ function test(inputCollection, output) {
 }
 
 // Setup JSCodeShift
-const plugins = imports.createPlugins(imports.config.CJSBasicRequire);
-jscodeshift.registerMethods({
-  addBasicImport: plugins.addImport,
-});
+jscodeshift.use(imports(imports.config.CJSBasicRequire))
 
 describe('addImportCJSBasicConfig', () => {
   it('should add to block start', () => {
@@ -35,7 +32,7 @@ describe('addImportCJSBasicConfig', () => {
 
       aaa;
     `)
-    .addBasicImport(statement`
+    .addImport(statement`
       var A0 = require('A0');
     `);
 
@@ -55,7 +52,7 @@ describe('addImportCJSBasicConfig', () => {
 
       aaa;
     `)
-    .addBasicImport(statement`
+    .addImport(statement`
       var A2 = require('A2');
     `);
 
@@ -75,7 +72,7 @@ describe('addImportCJSBasicConfig', () => {
 
       aaa;
     `)
-    .addBasicImport(statement`
+    .addImport(statement`
       var A4 = require('A4');
     `);
 
@@ -98,7 +95,7 @@ describe('addImportCJSBasicConfig', () => {
   //
   //     aaa;
   //   `)
-  //   .addBasicImport(statement`
+  //   .addImport(statement`
   //     var A0 = require('A0');
   //   `);
   //
@@ -124,7 +121,7 @@ describe('addImportCJSBasicConfig', () => {
 
       aaa;
     `)
-    .addBasicImport(statement`
+    .addImport(statement`
       var A0 = require('A0');
     `);
 
@@ -157,7 +154,7 @@ describe('addImportCJSBasicConfig', () => {
   //
   //     aaa;
   //   `)
-  //   .addBasicImport(statement`
+  //   .addImport(statement`
   //     var A5 = require('A5');
   //   `);
   //
@@ -190,7 +187,7 @@ describe('addImportCJSBasicConfig', () => {
 
       aaa;
     `)
-    .addBasicImport(statement`
+    .addImport(statement`
       var A5 = require('A5');
     `);
 
@@ -216,7 +213,7 @@ describe('addImportCJSBasicConfig', () => {
 
       aaa;
     `)
-    .addBasicImport(statement`
+    .addImport(statement`
       var A1 = require('A1');
     `);
 
@@ -237,7 +234,7 @@ describe('addImportCJSBasicConfig', () => {
 
       aaa;
     `)
-    .addBasicImport(statement`
+    .addImport(statement`
       var A1 = require('A1');
     `);
 
@@ -262,13 +259,13 @@ describe('addImportCJSBasicConfig', () => {
 
       aaa;
     `)
-    .addBasicImport(statement`
+    .addImport(statement`
       var A0 = require('A0');
     `)
-    .addBasicImport(statement`
+    .addImport(statement`
       var A2 = require('A2');
     `)
-    .addBasicImport(statement`
+    .addImport(statement`
       var A3 = require('A3');
     `);
 

--- a/extensions/imports/__tests__/addImportFBConfig-test.js
+++ b/extensions/imports/__tests__/addImportFBConfig-test.js
@@ -22,10 +22,7 @@ function test(inputCollection, output) {
 }
 
 // Setup JSCodeShift
-const plugins = imports.createPlugins(imports.config.FBRequire);
-jscodeshift.registerMethods({
-  addFBImport: plugins.addImport,
-});
+jscodeshift.use(imports(imports.config.FBRequire))
 
 describe('addImportFBConfig', () => {
   it('should add to block start large', () => {
@@ -37,7 +34,7 @@ describe('addImportFBConfig', () => {
 
       aaa;
     `)
-    .addFBImport(statement`
+    .addImport(statement`
       var A0 = require('A0');
     `);
 
@@ -60,7 +57,7 @@ describe('addImportFBConfig', () => {
 
       aaa;
     `)
-    .addFBImport(statement`
+    .addImport(statement`
       var a0 = require('a0');
     `);
 
@@ -85,7 +82,7 @@ describe('addImportFBConfig', () => {
 
       aaa;
     `)
-    .addFBImport(statement`
+    .addImport(statement`
       var a2 = require('a2');
     `);
 
@@ -111,7 +108,7 @@ describe('addImportFBConfig', () => {
 
       aaa;
     `)
-    .addFBImport(statement`
+    .addImport(statement`
       var a2 = require('a2');
     `);
 
@@ -138,7 +135,7 @@ describe('addImportFBConfig', () => {
 
       aaa;
     `)
-    .addFBImport(statement`
+    .addImport(statement`
       var A1 = require('A1');
     `);
 
@@ -166,13 +163,13 @@ describe('addImportFBConfig', () => {
   //
   //     aaa;
   //   `)
-  //   .addFBImport(statement`
+  //   .addImport(statement`
   //     var A0 = require('A0');
   //   `)
-  //   .addFBImport(statement`
+  //   .addImport(statement`
   //     var a2 = require('a2');
   //   `)
-  //   .addFBImport(statement`
+  //   .addImport(statement`
   //     var A3 = require('A3');
   //   `);
   //

--- a/extensions/imports/addImport.js
+++ b/extensions/imports/addImport.js
@@ -1,139 +1,142 @@
 'use strict';
 
-const j = require('jscodeshift');
+function makeAddImport(j) {
+  const statements = j.template.statements;
+  const statement = j.template.statement;
 
-const statements = j.template.statements;
-const statement = j.template.statement;
+  function findViaConfigType(type, nodePath) {
+    return j(nodePath)
+      .find(type.searchTerms[0])
+      .filter(p => type.filters.every(filter => filter(p)));
+  }
 
-function findViaConfigType(type, nodePath) {
-  return j(nodePath)
-    .find(type.searchTerms[0])
-    .filter(p => type.filters.every(filter => filter(p)));
-}
-
-function findInsertTypeIndex(config, requireStatement) {
-  const wrappedRequireStatement = j.program([requireStatement]);
-  for (let i = 0; i < config.length; i++) {
-    if (findViaConfigType(config[i], wrappedRequireStatement).size()) {
-      return i;
+  function findInsertTypeIndex(config, requireStatement) {
+    const wrappedRequireStatement = j.program([requireStatement]);
+    for (let i = 0; i < config.length; i++) {
+      if (findViaConfigType(config[i], wrappedRequireStatement).size()) {
+        return i;
+      }
     }
+
+    throw new Error('No valid config found!');
   }
 
-  throw new Error('No valid config found!');
-}
-
-function findNextInsertIndex(config, root) {
-  for (let i = config.length - 1; i >= 0; i--) {
-    if (findViaConfigType(config[i], root).size()) {
-      return i;
+  function findNextInsertIndex(config, root) {
+    for (let i = config.length - 1; i >= 0; i--) {
+      if (findViaConfigType(config[i], root).size()) {
+        return i;
+      }
     }
+
+    return -1;
   }
 
-  return -1;
-}
-
-function reprintComment(node) {
-  if (node.type === 'Block') {
-    return j.block(node.value);
-  } else if (node.type === 'Line') {
-    return j.line(node.value);
-  }
-  return node;
-}
-
-function applyCommentsToStatements(nodes, comments) {
-  if (comments) {
-    nodes[0].comments = comments.map(comment => reprintComment(comment));
-  }
-  return nodes;
-}
-
-function reprintNode(node) {
-  if (j.ExpressionStatement.check(node)) {
-    return statement`${node.expression}`;
-  }
-
-  if (j.VariableDeclaration.check(node)) {
-    const declaration = node.declarations[0];
-    return j.variableDeclaration(node.kind, [
-      j.variableDeclarator(declaration.id, declaration.init),
-    ]);
-  }
-
-  if (j.ImportDeclaration.check(node) && node.importKind === 'type') {
-    // TODO: Properly remove new lines from the node.
+  function reprintComment(node) {
+    if (node.type === 'Block') {
+      return j.block(node.value);
+    } else if (node.type === 'Line') {
+      return j.line(node.value);
+    }
     return node;
   }
 
-  return node;
-}
+  function applyCommentsToStatements(nodes, comments) {
+    if (comments) {
+      nodes[0].comments = comments.map(comment => reprintComment(comment));
+    }
+    return nodes;
+  }
 
-function addImport(config, root, requireStatement) {
-  const insertTypeIndex = findInsertTypeIndex(config, requireStatement);
-  const currentType = config[insertTypeIndex];
-  const nodesForType = findViaConfigType(currentType, root).paths();
+  function reprintNode(node) {
+    if (j.ExpressionStatement.check(node)) {
+      return statement`${node.expression}`;
+    }
 
-  if (nodesForType.length) {
-    let insertAt = nodesForType.length;
-    for (let i = 0; i < nodesForType.length; i++) {
-      const pos = currentType.comparator(
-        nodesForType[i].value,
-        requireStatement
+    if (j.VariableDeclaration.check(node)) {
+      const declaration = node.declarations[0];
+      return j.variableDeclaration(node.kind, [
+        j.variableDeclarator(declaration.id, declaration.init),
+      ]);
+    }
+
+    if (j.ImportDeclaration.check(node) && node.importKind === 'type') {
+      // TODO: Properly remove new lines from the node.
+      return node;
+    }
+
+    return node;
+  }
+
+  function addImport(config, root, requireStatement) {
+    const insertTypeIndex = findInsertTypeIndex(config, requireStatement);
+    const currentType = config[insertTypeIndex];
+    const nodesForType = findViaConfigType(currentType, root).paths();
+
+    if (nodesForType.length) {
+      let insertAt = nodesForType.length;
+      for (let i = 0; i < nodesForType.length; i++) {
+        const pos = currentType.comparator(
+          nodesForType[i].value,
+          requireStatement
+        );
+
+        if (pos >= 0) {
+          insertAt = i;
+          break;
+        }
+      }
+
+      if (insertAt === 0) {
+        const nodePath = nodesForType[0];
+        j(nodePath)
+          .replaceWith(applyCommentsToStatements(statements`
+            ${requireStatement};
+            ${reprintNode(nodePath.value)};
+          `, nodePath.value.comments));
+      } else {
+        const nodePath = nodesForType[insertAt - 1];
+        j(nodePath)
+          .replaceWith(applyCommentsToStatements(statements`
+            ${reprintNode(nodePath.value)};
+            ${requireStatement};
+          `, nodePath.value.comments));
+      }
+    } else {
+      const nextFoundConfigTypeIndex = findNextInsertIndex(
+        config,
+        root
       );
 
-      if (pos >= 0) {
-        insertAt = i;
-        break;
-      }
-    }
+      if (nextFoundConfigTypeIndex > -1) {
+        const requiresForType = findViaConfigType(
+          config[nextFoundConfigTypeIndex],
+          root
+        ).paths();
 
-    if (insertAt === 0) {
-      const nodePath = nodesForType[0];
-      j(nodePath)
-        .replaceWith(applyCommentsToStatements(statements`
-          ${requireStatement};
-          ${reprintNode(nodePath.value)};
-        `, nodePath.value.comments));
-    } else {
-      const nodePath = nodesForType[insertAt - 1];
-      j(nodePath)
-        .replaceWith(applyCommentsToStatements(statements`
-          ${reprintNode(nodePath.value)};
-          ${requireStatement};
-        `, nodePath.value.comments));
-    }
-  } else {
-    const nextFoundConfigTypeIndex = findNextInsertIndex(
-      config,
-      root
-    );
-
-    if (nextFoundConfigTypeIndex > -1) {
-      const requiresForType = findViaConfigType(
-        config[nextFoundConfigTypeIndex],
-        root
-      ).paths();
-
-      if (insertTypeIndex < nextFoundConfigTypeIndex) {
-        j(requiresForType[0])
-          .insertBefore(requireStatement);
+        if (insertTypeIndex < nextFoundConfigTypeIndex) {
+          j(requiresForType[0])
+            .insertBefore(requireStatement);
+        } else {
+          j(requiresForType[requiresForType.length - 1])
+            .insertAfter(requireStatement);
+        }
       } else {
-        j(requiresForType[requiresForType.length - 1])
-          .insertAfter(requireStatement);
-      }
-    } else {
-      const firstPath = j(root)
-        .find(j.Program)
-        .get('body')
-        .get(0);
+        const firstPath = j(root)
+          .find(j.Program)
+          .get('body')
+          .get(0);
 
-      j(firstPath)
-        .replaceWith(applyCommentsToStatements(statements`
-          ${requireStatement};
-          ${reprintNode(firstPath.value)};
-        `, firstPath.value.comments));
+        j(firstPath)
+          .replaceWith(applyCommentsToStatements(statements`
+            ${requireStatement};
+            ${reprintNode(firstPath.value)};
+          `, firstPath.value.comments));
+      }
     }
   }
+
+  return addImport;
 }
 
-module.exports = addImport;
+
+module.exports = makeAddImport;

--- a/extensions/imports/config/CJSBasicRequireConfig.js
+++ b/extensions/imports/config/CJSBasicRequireConfig.js
@@ -4,19 +4,18 @@ const StringUtils = require('nuclide-format-js-base/lib/utils/StringUtils');
 const getDeclarationName = require('../utils/getDeclarationName');
 const isGlobal = require('nuclide-format-js-base/lib/utils/isGlobal');
 const isValidRequireDeclaration = require('../utils/isValidRequireDeclaration');
-const jscs = require('jscodeshift');
 
-module.exports = [
+module.exports = jscs => [
   // Handle general requires, e.g: `require('lowerCase');`
   {
     searchTerms: [jscs.VariableDeclaration],
     filters: [
       isGlobal,
-      path => isValidRequireDeclaration(path.node),
+      path => isValidRequireDeclaration(jscs, path.node),
     ],
     comparator: (node1, node2) => StringUtils.compareStrings(
-      getDeclarationName(node1),
-      getDeclarationName(node2)
+      getDeclarationName(jscs, node1),
+      getDeclarationName(jscs, node2)
     ),
   },
 ];

--- a/extensions/imports/config/FBRequireConfig.js
+++ b/extensions/imports/config/FBRequireConfig.js
@@ -4,20 +4,19 @@ const StringUtils = require('nuclide-format-js-base/lib/utils/StringUtils');
 const getDeclarationName = require('../utils/getDeclarationName');
 const isGlobal = require('nuclide-format-js-base/lib/utils/isGlobal');
 const isValidRequireDeclaration = require('../utils/isValidRequireDeclaration');
-const jscs = require('jscodeshift');
 
-module.exports = [
+module.exports = jscs => [
   // Handle UpperCase requires, e.g: `require('UpperCase');`
   {
     searchTerms: [jscs.VariableDeclaration],
     filters: [
       isGlobal,
-      path => isValidRequireDeclaration(path.node),
-      path => StringUtils.isCapitalized(getDeclarationName(path.node)),
+      path => isValidRequireDeclaration(jscs, path.node),
+      path => StringUtils.isCapitalized(getDeclarationName(jscs, path.node)),
     ],
     comparator: (node1, node2) => StringUtils.compareStrings(
-      getDeclarationName(node1),
-      getDeclarationName(node2)
+      getDeclarationName(jscs, node1),
+      getDeclarationName(jscs, node2)
     ),
   },
 
@@ -26,12 +25,12 @@ module.exports = [
     searchTerms: [jscs.VariableDeclaration],
     filters: [
       isGlobal,
-      path => isValidRequireDeclaration(path.node),
-      path => !StringUtils.isCapitalized(getDeclarationName(path.node)),
+      path => isValidRequireDeclaration(jscs, path.node),
+      path => !StringUtils.isCapitalized(getDeclarationName(jscs, path.node)),
     ],
     comparator: (node1, node2) => StringUtils.compareStrings(
-      getDeclarationName(node1),
-      getDeclarationName(node2)
+      getDeclarationName(jscs, node1),
+      getDeclarationName(jscs, node2)
     ),
   },
 ];

--- a/extensions/imports/index.js
+++ b/extensions/imports/index.js
@@ -1,18 +1,23 @@
 'use strict';
 
-const addImport = require('./addImport');
+const makeAddImport = require('./addImport');
 const CJSBasicRequireConfig = require('./config/CJSBasicRequireConfig');
 const FBRequireConfig = require('./config/FBRequireConfig');
 
-module.exports = {
-  register(jscodeshift, config) {
-    const plugins = this.createPlugins(config);
-    jscodeshift.registerMethods(plugins);
-  },
+/**
+ * Create extension. Takes a config fn and returns a `use`-able plugin fn.
+ *
+ * Usage:
+ *   jscodeshift.use(imports(imports.config.CJSBasicRequire));
+ */
+ function imports(makeConfig) {
+  makeConfig = makeConfig || CJSBasicRequireConfig;
 
-  createPlugins(config) {
-    return {
+  return function importsPlugin(jscodeshift) {
+    const config = makeConfig(jscodeshift);
+    const addImport = makeAddImport(jscodeshift);
 
+    jscodeshift.registerMethods({
       /**
        * Add a new import statement.
        *
@@ -28,11 +33,13 @@ module.exports = {
           addImport(config, path, importStatement);
         });
       },
-    };
-  },
-
-  config: {
-    CJSBasicRequire: CJSBasicRequireConfig,
-    FBRequire: FBRequireConfig,
-  },
+    })
+  }
 };
+
+imports.config = {
+  CJSBasicRequire: CJSBasicRequireConfig,
+  FBRequire: FBRequireConfig,
+};
+
+module.exports = imports;

--- a/extensions/imports/package.json
+++ b/extensions/imports/package.json
@@ -13,7 +13,9 @@
     "import"
   ],
   "dependencies": {
-    "jscodeshift": "^0.3.0",
     "nuclide-format-js-base": "^0.0.35"
+  },
+  "peerDependencies": {
+    "jscodeshift": "^0.3.0"
   }
 }

--- a/extensions/imports/utils/getDeclarationName.js
+++ b/extensions/imports/utils/getDeclarationName.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const jscs = require('jscodeshift');
-
-function getDeclarationName(node) {
+function getDeclarationName(jscs, node) {
   var declaration = node.declarations[0];
   if (jscs.Identifier.check(declaration.id)) {
     return declaration.id.name;

--- a/extensions/imports/utils/isValidRequireDeclaration.js
+++ b/extensions/imports/utils/isValidRequireDeclaration.js
@@ -1,9 +1,8 @@
 'use strict';
 
-const jscs = require('jscodeshift');
 const hasOneRequireDeclaration = require('nuclide-format-js-base/lib/utils/hasOneRequireDeclaration');
 
-function isValidRequireDeclaration(node) {
+function isValidRequireDeclaration(jscs, node) {
   if (!hasOneRequireDeclaration(node)) {
     return false;
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "recast"
   ],
   "dependencies": {
-    "jscodeshift": "^0.3.20",
     "nuclide-format-js-base": "0.0.35"
   },
   "devDependencies": {
@@ -28,6 +27,9 @@
     "eslint": "^1.7.3",
     "fbjs-scripts": "^0.5.0",
     "jest-cli": "^11.0.2"
+  },
+  "peerDependencies": {
+    "jscodeshift": "^0.3.20"
   },
   "jest": {
     "automock": false,


### PR DESCRIPTION
**This breaks this plugin's api.** It also entirely removes the dependency on
jscodeshift itself. Instead, it exports a factory function that takes a config,
now also functions, and returns a `use`-able plugin to be registered with
jscodeshift.

As a result of moving away from the user invoking `registerMethods` directly,
we lose the ability to provide a custom name to the plugin's methods, but we
also avoid leaking the registration process to the user, and things are much
simpler IMHO.