### PR TITLE
Add proper const/ let decisions for for loops

### DIFF
--- a/transforms/__testfixtures__/no-vars.input.js
+++ b/transforms/__testfixtures__/no-vars.input.js
@@ -34,6 +34,11 @@ for (var [key, value] of object.entries()) {
   console.log(key, value);
 }
 
+for (var [keyTwo, valueTwo] of object.entries()) {
+  keyTwo = 'something';
+  console.log(keyTwo, valueTwo);
+}
+
 var whileIterator = 10;
 while (whileIterator > 0) {
   whileIterator--;

--- a/transforms/__testfixtures__/no-vars.output.js
+++ b/transforms/__testfixtures__/no-vars.output.js
@@ -19,7 +19,7 @@ function mutate() {
 
 const array = ['a', 'b', 'c', 'd'];
 
-for (let letter in array) {
+for (const letter in array) {
   console.log(letter);
 }
 
@@ -30,8 +30,13 @@ const object = {
   'd': 4,
 };
 
-for (let [key, value] of object.entries()) {
+for (const [key, value] of object.entries()) {
   console.log(key, value);
+}
+
+for (let [keyTwo, valueTwo] of object.entries()) {
+  keyTwo = 'something';
+  console.log(keyTwo, valueTwo);
 }
 
 let whileIterator = 10;

--- a/transforms/no-vars.js
+++ b/transforms/no-vars.js
@@ -30,6 +30,10 @@ export default function(file, api) {
     }
     return node !== container ? node : null;
   };
+  const isForLoopDeclarationWithoutInit = declaration => {
+    const parentType = declaration.parentPath.value.type;
+    return parentType === 'ForOfStatement' || parentType === 'ForInStatement';
+  };
 
   const extractNamesFromIdentifierLike = id => {
     if (!id) {
@@ -213,9 +217,10 @@ export default function(file, api) {
       return !isTruelyVar(declaration, declarator);
     });
   }).forEach(declaration => {
+    const forLoopWithoutInit = isForLoopDeclarationWithoutInit(declaration);
     if (
       declaration.value.declarations.some(declarator => {
-        return !declarator.init || isMutated(declaration, declarator);
+        return (!declarator.init && !forLoopWithoutInit) || isMutated(declaration, declarator);
       })
     ) {
       declaration.value.kind = 'let';


### PR DESCRIPTION
This PR fixes detection of `let`/ `const` in `for in` and `for of` loops. Before this, any declaration without an `init` was being handled as a `let`, which is still the correct handling of the generic `let foo;` case. However, `for in` and `for of` loops are special cases of declarations in that they have a kind of implicit initialization for each run of the loop. This PR detects this case and allows it to continue onto the "is this mutated?" stage of the process.

A bunch of tests fail and there are two linter warnings, but these appear to be on master, too.

cc/ @cpojer @pieterv @voideanvalue
cc/ @bouk