### PR TITLE
add requires alphabetic sort

### DIFF
--- a/transforms/__testfixtures__/sort-requires.input.js
+++ b/transforms/__testfixtures__/sort-requires.input.js
@@ -1,0 +1,11 @@
+"use strict";
+var ddd = require('../foo/bar');
+var ggg = require('ggg')(ccc);
+var aaa = require('aaa')(eee);
+var eee = require('eee');
+var ccc = require('ccc');
+var bbb = require('bbb');
+var foo = bbb.doSomething();
+var fff = require('fff');
+
+let restOfCode = 'foobaz';

--- a/transforms/__testfixtures__/sort-requires.output.js
+++ b/transforms/__testfixtures__/sort-requires.output.js
@@ -1,0 +1,11 @@
+"use strict";
+var bbb = require('bbb');
+var ccc = require('ccc');
+var ddd = require('../foo/bar');
+var eee = require('eee');
+var fff = require('fff');
+var aaa = require('aaa')(eee);
+var ggg = require('ggg')(ccc);
+var foo = bbb.doSomething();
+
+let restOfCode = 'foobaz';

--- a/transforms/__tests__/sort-requires-test.js
+++ b/transforms/__tests__/sort-requires-test.js
@@ -1,0 +1,4 @@
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+defineTest(__dirname, 'sort-requires');

--- a/transforms/sort-requires.js
+++ b/transforms/sort-requires.js
@@ -1,0 +1,50 @@
+module.exports = (file, api) => {
+  const j = api.jscodeshift;
+  const sort = (a, b) => a.declarations[0].id.name.localeCompare(
+    b.declarations[0].id.name
+  );
+  const root = j(file.source);
+  const requires = root
+    .find(j.CallExpression, {
+      callee: {
+        name: 'require'
+      }
+    })
+    .closest(j.VariableDeclaration);
+
+  let organizedRequires = [];
+
+  // check for strict mode expression
+  const strict = root.find(j.ExpressionStatement, {
+    expression: {
+      value: 'use strict'
+    }
+  });
+  const strictNode = strict.nodes();
+  organizedRequires = organizedRequires.concat(strictNode);
+  strict.remove();
+
+  // check for dependencies between requires
+  const dependencies = requires.filter(req => {
+    return req.node.declarations[0].init.arguments[0].type == 'Identifier';
+  });
+  const sortedDependencies = dependencies.nodes().sort(sort);
+  dependencies.remove();
+
+  // get normal, non dependent, requires
+  const nonDependentRequires = requires.filter(req => {
+    const declarations = req.node.declarations;
+    return declarations && declarations[0].init.arguments[0].type == 'Literal';
+  });
+  const sortedRequires = nonDependentRequires.nodes().sort(sort);
+  organizedRequires = organizedRequires.concat(sortedRequires);
+  nonDependentRequires.remove();
+
+  // add back requires with dependencies, after nonDependentRequires
+  organizedRequires = organizedRequires.concat(sortedDependencies);
+
+  return root.find(j.Statement)
+    .at(0)
+    .insertBefore(organizedRequires)
+    .toSource();
+};


### PR DESCRIPTION
This codemod sorts requires alphabetically, moving them to the top of the document. 

It makes a simple check for _requires_ that depend on other _requires_, and adds these later.
It keeps `"use strict";` at top if present.

https://astexplorer.net/#/HPwPYV4rcI/6