### PR TITLE
Change arrow-function to transfer comments from the old AST

### DIFF
--- a/transforms/__testfixtures__/arrow-function.input.js
+++ b/transforms/__testfixtures__/arrow-function.input.js
@@ -28,6 +28,11 @@ var fn6 = (function() {
   };
 }).bind(this);
 
+var fn7 = /*1*/(/*2*/function/*3*/(/*4*/)/*5*/ {/*6*/
+  console.log('Keep');
+  console.log('comments');
+}/*7*/)/*8*/./*9*/bind/*10*/(/*11*/this/*12*/)/*13*/;
+
 [1, 2, 3].map(function(x) {
   return x * x;
 }.bind(this));
@@ -40,6 +45,10 @@ compare(1, 2, function(num1, num2) {
   return num1 > num2;
 });
 
+/*1*/compare/*2*/(/*3*/1, /*4*/2, /*5*/function/*6*/(/*7*/num1/*8*/, /*9*/num2/*10*/) /*11*/{
+  /*12*/return /*13*/num1 > num2/*14*/;/*15*/
+}/*16*/)/*17*/;/*18*/
+
 Promise.resolve()
 .then(function() {
   console.log('foo');
@@ -47,6 +56,10 @@ Promise.resolve()
 .then(function(a) {
   return 4;
 });
+
+foo(function() /*1*/{
+  /*2*/console.log('Keep comments when inlining single expressions');
+/*3*/}/*4*/);
 
 foo(function(a) {
   this.bar(function() {

--- a/transforms/__testfixtures__/arrow-function.output.js
+++ b/transforms/__testfixtures__/arrow-function.output.js
@@ -22,17 +22,27 @@ var fn6 = () => ({
   a: 1,
 });
 
+var fn7 = /*2*//*1*/() => /*3*//*4*//*5*/ {/*6*/
+  console.log('Keep');
+  console.log('comments');
+}/*7*//*8*//*10*//*9*//*11*//*12*//*13*/;
+
 [1, 2, 3].map(x => x * x);
 
 [1, 2, 3].map(x => x * x);
 
 compare(1, 2, (num1, num2) => num1 > num2);
 
+/*1*/compare/*2*/(/*3*/1, /*4*/2, /*5*/(/*6*//*7*/num1/*8*/, /*9*/num2/*10*/) => /*13*//*11*//*12*/num1 > num2/*14*//*15*//*16*/)/*17*/;/*18*/
+
 Promise.resolve()
 .then(function() {
   console.log('foo');
 }.bind(this, 'a'))
 .then(a => 4);
+
+foo(() => /*1*//*2*/console.log('Keep comments when inlining single expressions')
+/*3*//*4*/);
 
 foo(function(a) {
   this.bar(function() {


### PR DESCRIPTION
For the test, my main concern is that every comment in the input appears
somewhere in the output (even if the order changes).

Also, looks like there are two pre-existing test failures unrelated to `arrow-function`.
At least for me, all `arrow-function` tests pass, including my new cases.