### PR TITLE
Spread operator no longer supported in jscodeshift 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["es2015"],
-  "plugins": ["transform-object-rest-spread"]
+  "presets": ["es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -17,13 +17,12 @@
     "recast"
   ],
   "dependencies": {
-    "jscodeshift": "^0.3.20",
+    "jscodeshift": "^0.3.25",
     "nuclide-format-js-base": "0.0.35"
   },
   "devDependencies": {
     "babel-eslint": "^5.0.0",
     "babel-jest": "^9.0.2",
-    "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "eslint": "^1.7.3",
     "fbjs-scripts": "^0.5.0",

--- a/transforms/trailing-commas.js
+++ b/transforms/trailing-commas.js
@@ -36,9 +36,8 @@ export default function(file, api, options) {
     .filter(arrayHasNoTrailingComma)
     .forEach(forceReprint);
 
-  return root.toSource({
-    ...options.printOptions,
+  return root.toSource(Object.assign({}, options.printOptions, {
     trailingComma: true,
     wrapColumn: 1, // Makes sure we write each values on a separate line.
-  });
+  }));
 }


### PR DESCRIPTION
After updating jscodeshift from 0.3.20 to 0.3.25 I noticed that I could no longer run the trailing comma transform. Instead I got an error pointing out the object spread operator as an unexpected token. I removed the transform from js-codemod and updated the jscodeshift dependency to 0.3.25 and then I got the test to fail with the same error.

```
» ./node_modules/.bin/jest transforms/__tests__/trailing-commas-test.js
Using Jest CLI v11.0.2, jasmine2, babel-jest
 FAIL  transforms/__tests__/trailing-commas-test.js (3.728s)
● trailing-commas › it transforms correctly
  - SyntaxError: /Users/erikbrannstrom/js-codemod/transforms/trailing-commas.js: Unexpected token (40:4)
      38 |
      39 |   return root.toSource({
    > 40 |     ...options.printOptions,
         |     ^
      41 |     trailingComma: true,
      42 |     wrapColumn: 1, // Makes sure we write each values on a separate line.
      43 |   });
1 test failed, 0 tests passed (1 total in 1 test suite, run time 4.595s)
```

The issue seems to be that jscodeshift removed their babel build step in 0.3.21 and instead only rely on the features in node. They explicitly mention in https://github.com/facebook/jscodeshift/pull/119 that the obejct spread operator was manually removed in order to make this work, so I did exactly that in transforms/trailing-commas.js which fixed the problem.