### PR TITLE
Fix recursive methods in object shorthand

### DIFF
--- a/transforms/__testfixtures__/object-shorthand.input.js
+++ b/transforms/__testfixtures__/object-shorthand.input.js
@@ -13,4 +13,13 @@ const myObj = {
   ['computed' + 'property']: 1,
   method: function() { },
   method2: () => { },
+  method3: function foo(n) {
+    if (n === 0) {
+      return n;
+    }
+    return foo(n - 1) + n;
+  },
+  method4: function whatever() {
+    return one;
+  },
 };

--- a/transforms/__testfixtures__/object-shorthand.output.js
+++ b/transforms/__testfixtures__/object-shorthand.output.js
@@ -13,4 +13,13 @@ const myObj = {
   ['computed' + 'property']: 1,
   method() { },
   method2: () => { },
+  method3: function foo(n) {
+    if (n === 0) {
+      return n;
+    }
+    return foo(n - 1) + n;
+  },
+  method4() {
+    return one;
+  },
 };

--- a/transforms/object-shorthand.js
+++ b/transforms/object-shorthand.js
@@ -24,15 +24,26 @@ module.exports = (file, api, options) => {
   const printOptions = options.printOptions || {quote: 'single'};
   const root = j(file.source);
 
+  const isRecursive = (value) => {
+    return !!(
+      value.id &&
+      j(value.body).find(j.Identifier).filter(
+        i => i.node.name === value.id.name
+      ).size() !== 0
+    );
+  };
+
   const canBeSimplified = (key, value) => {
     // Can be simplified if both key and value are the same identifier or if the
-    // property is a method.
+    // property is a method that is not recursive
     if (key.type === 'Identifier') {
       return (
           value.type === 'Identifier' &&
           key.name === value.name
-        ) ||
-        value.type === 'FunctionExpression';
+        ) || (
+          value.type === 'FunctionExpression' &&
+          !isRecursive(value)
+        );
     }
 
     // Can be simplified if the key is a string literal which is equal to the


### PR DESCRIPTION
Recursive methods should not be transformed to the shorthand.