### PR TITLE
Add remove-describe transform

### DIFF
--- a/transforms/__testfixtures__/jest-remove-describe.input.js
+++ b/transforms/__testfixtures__/jest-remove-describe.input.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactTestUtils;
+
+var AutoMockedComponent;
+var MockedComponent;
+
+describe('ReactMockedComponent', function() {
+
+  beforeEach(function() {
+    React = require('React');
+    ReactTestUtils = require('ReactTestUtils');
+
+    AutoMockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+    MockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+
+    ReactTestUtils.mockComponent(MockedComponent);
+  });
+
+  it('should allow an implicitly mocked component to be rendered without warnings', () => {
+    spyOn(console, 'error');
+    ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+    expect(console.error.calls.count()).toBe(0);
+  });
+
+  it('should allow an implicitly mocked component to be updated', () => {
+    class Wrapper extends React.Component {
+      state = {foo: 1};
+
+      update = () => {
+        this.setState({foo: 2});
+      };
+
+      render() {
+        return <div><AutoMockedComponent prop={this.state.foo} /></div>;
+      }
+    }
+
+    var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+
+    var found = ReactTestUtils.findRenderedComponentWithType(
+      instance,
+      AutoMockedComponent
+    );
+    expect(typeof found).toBe('object');
+
+    instance.update();
+  });
+
+  it('has custom methods on the implicitly mocked component', () => {
+    var instance = ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+    expect(typeof instance.hasCustomMethod).toBe('function');
+  });
+
+  it('should allow an explicitly mocked component to be rendered', () => {
+    ReactTestUtils.renderIntoDocument(<MockedComponent />);
+  });
+
+  it('should allow an explicitly mocked component to be updated', () => {
+    class Wrapper extends React.Component {
+      state = {foo: 1};
+
+      update = () => {
+        this.setState({foo: 2});
+      };
+
+      render() {
+        return <div><MockedComponent prop={this.state.foo} /></div>;
+      }
+    }
+
+    var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+
+    var found = ReactTestUtils.findRenderedComponentWithType(
+      instance,
+      MockedComponent
+    );
+    expect(typeof found).toBe('object');
+
+    instance.update();
+  });
+
+  it('has custom methods on the explicitly mocked component', () => {
+    var instance = ReactTestUtils.renderIntoDocument(<MockedComponent />);
+    expect(typeof instance.hasCustomMethod).toBe('function');
+  });
+
+});

--- a/transforms/__testfixtures__/jest-remove-describe.output.js
+++ b/transforms/__testfixtures__/jest-remove-describe.output.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+'use strict';
+
+var React;
+var ReactTestUtils;
+
+var AutoMockedComponent;
+var MockedComponent;
+
+beforeEach(function() {
+  React = require('React');
+  ReactTestUtils = require('ReactTestUtils');
+
+  AutoMockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+  MockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+
+  ReactTestUtils.mockComponent(MockedComponent);
+});
+
+it('should allow an implicitly mocked component to be rendered without warnings', () => {
+  spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('should allow an implicitly mocked component to be updated', () => {
+  class Wrapper extends React.Component {
+    state = {foo: 1};
+
+    update = () => {
+      this.setState({foo: 2});
+    };
+
+    render() {
+      return <div><AutoMockedComponent prop={this.state.foo} /></div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+
+  var found = ReactTestUtils.findRenderedComponentWithType(
+    instance,
+    AutoMockedComponent
+  );
+  expect(typeof found).toBe('object');
+
+  instance.update();
+});
+
+it('has custom methods on the implicitly mocked component', () => {
+  var instance = ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+  expect(typeof instance.hasCustomMethod).toBe('function');
+});
+
+it('should allow an explicitly mocked component to be rendered', () => {
+  ReactTestUtils.renderIntoDocument(<MockedComponent />);
+});
+
+it('should allow an explicitly mocked component to be updated', () => {
+  class Wrapper extends React.Component {
+    state = {foo: 1};
+
+    update = () => {
+      this.setState({foo: 2});
+    };
+
+    render() {
+      return <div><MockedComponent prop={this.state.foo} /></div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+
+  var found = ReactTestUtils.findRenderedComponentWithType(
+    instance,
+    MockedComponent
+  );
+  expect(typeof found).toBe('object');
+
+  instance.update();
+});
+
+it('has custom methods on the explicitly mocked component', () => {
+  var instance = ReactTestUtils.renderIntoDocument(<MockedComponent />);
+  expect(typeof instance.hasCustomMethod).toBe('function');
+});

--- a/transforms/__tests__/jest-remove-describe-test.js
+++ b/transforms/__tests__/jest-remove-describe-test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+defineTest(__dirname, 'jest-remove-describe');

--- a/transforms/jest-remove-describe.js
+++ b/transforms/jest-remove-describe.js
@@ -1,0 +1,46 @@
+/**
+ * This removes the describe block when there's only one.
+ *
+ * Convert
+ * 
+ * describe("Name", function() {
+ *   it(...);
+ *   ...
+ * });
+ *
+ * into
+ *
+ * it(...);
+ * ...
+ *
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+
+  var describes = j(file.source)
+    .find(j.ExpressionStatement)
+    .filter(path =>
+            path.parentPath.node.type === 'Program' &&
+            path.node.expression.type === 'CallExpression' &&
+            path.node.expression.callee.type === 'Identifier' &&
+            path.node.expression.callee.name === 'describe');
+
+  if (describes.size() !== 1) {
+    return null;
+  }
+
+  describes.forEach(path => {
+    if (path.parentPath.node.type !== 'Program') {
+      return;
+    }
+    var parentBody = path.parentPath.node.body;
+    parentBody.splice(
+      parentBody.indexOf(path.node),
+      1,
+      ...path.node.expression.arguments[1].body.body
+    );
+  });
+
+  return describes.toSource();
+}


### PR DESCRIPTION
When there's only one describe block in a test file, we can safely remove it to remove noise.