### PR TITLE
Flow bool -> boolean

### DIFF
--- a/transforms/__testfixtures__/flow-bool-to-boolean.input.js
+++ b/transforms/__testfixtures__/flow-bool-to-boolean.input.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+var a: bool = 10;
+var b: boolean = 10;
+function c<T: bool>(x: bool): bool {
+  
+}

--- a/transforms/__testfixtures__/flow-bool-to-boolean.output.js
+++ b/transforms/__testfixtures__/flow-bool-to-boolean.output.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+var a: boolean = 10;
+var b: boolean = 10;
+function c<T: boolean>(x: boolean): boolean {
+  
+}

--- a/transforms/__tests__/flow-bool-to-boolean-test.js
+++ b/transforms/__tests__/flow-bool-to-boolean-test.js
@@ -1,0 +1,4 @@
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+defineTest(__dirname, 'flow-bool-to-boolean', null, 'flow-bool-to-boolean');

--- a/transforms/flow-bool-to-boolean.js
+++ b/transforms/flow-bool-to-boolean.js
@@ -1,0 +1,7 @@
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  return j(file.source)
+    .find(j.BooleanTypeAnnotation)
+    .replaceWith(j.booleanTypeAnnotation())
+    .toSource();
+}


### PR DESCRIPTION
It turns out that there's no difference between those two at the AST level. So I just replace it by the same thing which is going make it dirty and reprinted by recast with the correct one.