### PR TITLE
Add normal to arrow function transform for jest tests

### DIFF
--- a/transforms/__testfixtures__/jest-arrow.input.js
+++ b/transforms/__testfixtures__/jest-arrow.input.js
@@ -1,0 +1,23 @@
+describe('describe', function() {
+  it('should be happy', function() {
+    console.log('actually forwards body');
+  });
+  it('should leave existing arrow functions alone', () => {
+  });
+  describe('nested describe', function() {
+    xit('disabled one still count', function() {
+
+    });
+    xdescribe('disabled describe as well', function() {
+
+    });
+  });
+
+  beforeEach(function() {});
+  afterEach(function() {});
+});
+
+function containsit() {
+}
+containsit(function() {
+});

--- a/transforms/__testfixtures__/jest-arrow.output.js
+++ b/transforms/__testfixtures__/jest-arrow.output.js
@@ -1,0 +1,23 @@
+describe('describe', () => {
+  it('should be happy', () => {
+    console.log('actually forwards body');
+  });
+  it('should leave existing arrow functions alone', () => {
+  });
+  describe('nested describe', () => {
+    xit('disabled one still count', () => {
+
+    });
+    xdescribe('disabled describe as well', () => {
+
+    });
+  });
+
+  beforeEach(() => {});
+  afterEach(() => {});
+});
+
+function containsit() {
+}
+containsit(function() {
+});

--- a/transforms/__tests__/jest-arrow.js
+++ b/transforms/__tests__/jest-arrow.js
@@ -1,0 +1,4 @@
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+defineTest(__dirname, 'jest-arrow');

--- a/transforms/jest-arrow.js
+++ b/transforms/jest-arrow.js
@@ -1,0 +1,50 @@
+/**
+ * Transforms all the normal functions into arrow functions as callback of
+ * jest globals such as describe, it...
+ *
+ * describe(function() {
+ *   it('should work', function() {
+ *     ...
+ *   });
+ * });
+ *
+ * -->
+ *
+ * describe(() => {
+ *   it('should work', () => {
+ *     ...
+ *   });
+ * });
+ */
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+
+  const functionsToTransform = [
+    'describe',
+    'beforeEach',
+    'afterEach',
+    'it',
+    'xit',
+    'test',
+    'xdescribe',
+  ];
+
+  return j(file.source)
+    .find(j.ExpressionStatement)
+    .filter(path => {
+      return (
+        path.node.expression.type === 'CallExpression' &&
+        path.node.expression.callee.type === 'Identifier' &&
+        functionsToTransform.indexOf(path.node.expression.callee.name) !== -1
+      );
+    })
+    .forEach(path => {
+      var lastArg = path.node.expression.arguments.length - 1;
+      var fn = path.node.expression.arguments[lastArg];
+
+      path.node.expression.arguments[lastArg] = 
+        j.arrowFunctionExpression(fn.params, fn.body);
+    })
+    .toSource();
+}


### PR DESCRIPTION
```js
describe(function() {
  it('should work', function() {
    ...
  });
});
```

->

```js
describe(() => {
  it('should work', () => {
    ...
  });
});
```