### PR TITLE
Fixed erroneous export syntax in some transforms

### DIFF
--- a/transforms/no-vars.js
+++ b/transforms/no-vars.js
@@ -1,4 +1,4 @@
-export default function(file, api) {
+module.exports = function(file, api) {
   const j = api.jscodeshift;
 
   const root = j(file.source);

--- a/transforms/trailing-commas.js
+++ b/transforms/trailing-commas.js
@@ -1,7 +1,7 @@
 /**
  * Adds trailing commas to every object litteral and array.
  */
-export default function(file, api, options) {
+module.exports = function(file, api, options) {
   const j = api.jscodeshift;
 
   const objectHasNoTrailingComma = ({node}) => {


### PR DESCRIPTION
es6 syntax `export default` were used in some transforms
this was causing errors in some circumstances
see https://github.com/cpojer/js-codemod/issues/60