### PR TITLE
nuclide-format-js-base -> nuclide-format-js

### DIFF
--- a/extensions/imports/config/CJSBasicRequireConfig.js
+++ b/extensions/imports/config/CJSBasicRequireConfig.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const StringUtils = require('nuclide-format-js-base/lib/utils/StringUtils');
+const StringUtils = require('nuclide-format-js/lib/common/utils/StringUtils');
 const getDeclarationName = require('../utils/getDeclarationName');
-const isGlobal = require('nuclide-format-js-base/lib/utils/isGlobal');
+const isGlobal = require('nuclide-format-js/lib/common/utils/isGlobal');
 const isValidRequireDeclaration = require('../utils/isValidRequireDeclaration');
 const jscs = require('jscodeshift');
 

--- a/extensions/imports/config/FBRequireConfig.js
+++ b/extensions/imports/config/FBRequireConfig.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const StringUtils = require('nuclide-format-js-base/lib/utils/StringUtils');
+const StringUtils = require('nuclide-format-js/lib/common/utils/StringUtils');
 const getDeclarationName = require('../utils/getDeclarationName');
-const isGlobal = require('nuclide-format-js-base/lib/utils/isGlobal');
+const isGlobal = require('nuclide-format-js/lib/common/utils/isGlobal');
 const isValidRequireDeclaration = require('../utils/isValidRequireDeclaration');
 const jscs = require('jscodeshift');
 

--- a/extensions/imports/package.json
+++ b/extensions/imports/package.json
@@ -14,6 +14,6 @@
   ],
   "dependencies": {
     "jscodeshift": "^0.3.0",
-    "nuclide-format-js-base": "^0.0.35"
+    "nuclide-format-js": "0.0.36"
   }
 }

--- a/extensions/imports/utils/isValidRequireDeclaration.js
+++ b/extensions/imports/utils/isValidRequireDeclaration.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const jscs = require('jscodeshift');
-const hasOneRequireDeclaration = require('nuclide-format-js-base/lib/utils/hasOneRequireDeclaration');
+const hasOneRequireDeclaration = require('nuclide-format-js/lib/common/utils/hasOneRequireDeclaration');
 
 function isValidRequireDeclaration(node) {
   if (!hasOneRequireDeclaration(node)) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "jscodeshift": "^0.3.20",
-    "nuclide-format-js-base": "0.0.35"
+    "nuclide-format-js": "0.0.36"
   },
   "devDependencies": {
     "babel-eslint": "^5.0.0",


### PR DESCRIPTION
`nuclide-format-js-base` was replaced by `nuclide-format-js`, the code in 0.0.36 is the same as in 0.0.35, just in a different spot.

Test plan:

`npm test`.

cc: @cpojer 