### PR TITLE
add codemod to remove jest.disableAutomock()

### DIFF
--- a/transforms/__testfixtures__/jest-remove-disable-automock.input.js
+++ b/transforms/__testfixtures__/jest-remove-disable-automock.input.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+jest.disableAutomock();
+
+var React;
+var ReactTestUtils;
+
+var AutoMockedComponent;
+var MockedComponent;
+
+jest.disableAutomock().mock('xyz');
+jest.enableAutomock();
+jest.unmock('abc');
+jest.autoMockOff();
+
+beforeEach(function() {
+  jest.disableAutomock();
+  React = require('React');
+  ReactTestUtils = require('ReactTestUtils');
+
+  AutoMockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+  MockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+
+  ReactTestUtils.mockComponent(MockedComponent);
+});
+
+it('should allow an implicitly mocked component to be rendered without warnings', () => {
+  spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('should allow an implicitly mocked component to be updated', () => {
+  class Wrapper extends React.Component {
+    state = {foo: 1};
+
+    update = () => {
+      this.setState({foo: 2});
+    };
+
+    render() {
+      return <div><AutoMockedComponent prop={this.state.foo} /></div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+
+  var found = ReactTestUtils.findRenderedComponentWithType(
+    instance,
+    AutoMockedComponent
+  );
+  expect(typeof found).toBe('object');
+
+  instance.update();
+});
+
+it('has custom methods on the implicitly mocked component', () => {
+  var instance = ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+  expect(typeof instance.hasCustomMethod).toBe('function');
+});
+
+it('should allow an explicitly mocked component to be rendered', () => {
+  ReactTestUtils.renderIntoDocument(<MockedComponent />);
+});
+
+it('should allow an explicitly mocked component to be updated', () => {
+  class Wrapper extends React.Component {
+    state = {foo: 1};
+
+    update = () => {
+      this.setState({foo: 2});
+    };
+
+    render() {
+      return <div><MockedComponent prop={this.state.foo} /></div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+
+  var found = ReactTestUtils.findRenderedComponentWithType(
+    instance,
+    MockedComponent
+  );
+  expect(typeof found).toBe('object');
+
+  instance.update();
+});
+
+it('has custom methods on the explicitly mocked component', () => {
+  var instance = ReactTestUtils.renderIntoDocument(<MockedComponent />);
+  expect(typeof instance.hasCustomMethod).toBe('function');
+});
+

--- a/transforms/__testfixtures__/jest-remove-disable-automock.output.js
+++ b/transforms/__testfixtures__/jest-remove-disable-automock.output.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+
+var React;
+var ReactTestUtils;
+
+var AutoMockedComponent;
+var MockedComponent;
+
+jest.mock('xyz');
+jest.enableAutomock();
+jest.unmock('abc');
+
+beforeEach(function() {
+  React = require('React');
+  ReactTestUtils = require('ReactTestUtils');
+
+  AutoMockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+  MockedComponent = jest.genMockFromModule('ReactMockedComponentTestComponent');
+
+  ReactTestUtils.mockComponent(MockedComponent);
+});
+
+it('should allow an implicitly mocked component to be rendered without warnings', () => {
+  spyOn(console, 'error');
+  ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+  expect(console.error.calls.count()).toBe(0);
+});
+
+it('should allow an implicitly mocked component to be updated', () => {
+  class Wrapper extends React.Component {
+    state = {foo: 1};
+
+    update = () => {
+      this.setState({foo: 2});
+    };
+
+    render() {
+      return <div><AutoMockedComponent prop={this.state.foo} /></div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+
+  var found = ReactTestUtils.findRenderedComponentWithType(
+    instance,
+    AutoMockedComponent
+  );
+  expect(typeof found).toBe('object');
+
+  instance.update();
+});
+
+it('has custom methods on the implicitly mocked component', () => {
+  var instance = ReactTestUtils.renderIntoDocument(<AutoMockedComponent />);
+  expect(typeof instance.hasCustomMethod).toBe('function');
+});
+
+it('should allow an explicitly mocked component to be rendered', () => {
+  ReactTestUtils.renderIntoDocument(<MockedComponent />);
+});
+
+it('should allow an explicitly mocked component to be updated', () => {
+  class Wrapper extends React.Component {
+    state = {foo: 1};
+
+    update = () => {
+      this.setState({foo: 2});
+    };
+
+    render() {
+      return <div><MockedComponent prop={this.state.foo} /></div>;
+    }
+  }
+
+  var instance = ReactTestUtils.renderIntoDocument(<Wrapper />);
+
+  var found = ReactTestUtils.findRenderedComponentWithType(
+    instance,
+    MockedComponent
+  );
+  expect(typeof found).toBe('object');
+
+  instance.update();
+});
+
+it('has custom methods on the explicitly mocked component', () => {
+  var instance = ReactTestUtils.renderIntoDocument(<MockedComponent />);
+  expect(typeof instance.hasCustomMethod).toBe('function');
+});

--- a/transforms/__tests__/jest-remove-disable-automock-test.js
+++ b/transforms/__tests__/jest-remove-disable-automock-test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+defineTest(__dirname, 'jest-remove-disable-automock');

--- a/transforms/jest-remove-disable-automock.js
+++ b/transforms/jest-remove-disable-automock.js
@@ -1,0 +1,112 @@
+/**
+ * This removes jest.disableAutomock() calls. It handles cases where
+ * `disableAutomock` is part of a chain
+ * (ex. `jest.disableAutomock().mock('xyz')`)
+ * It also preserves any header comments at the top of the file if
+ * the the codemod completely deletes the first line.
+ */
+
+module.exports = function(file, api) {
+
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let mutations = 0;
+
+  const DISABLE_AUTOMOCK_CALLS = {
+    autoMockOff: 'disableAutomock',
+    disableAutomock: 'disableAutomock',
+  };
+
+  const isGeneratedFile = () => {
+    const rootElement = root.get(0).node.program.body[0];
+    const headers = !!rootElement && rootElement.comments;
+    return (
+      headers &&
+      headers.length > 0 &&
+      headers[0].value.indexOf('@generated') > -1
+    );
+  };
+
+  const isJestCall = (node) => (
+    node.name == 'jest' || (
+      node.type == 'CallExpression' &&
+      node.callee.type == 'MemberExpression' &&
+      isJestCall(node.callee.object)
+    )
+  );
+
+  const isRootElement = (path) => (
+    path &&
+    path.parentPath &&
+    path.parentPath.value === root.get(0).node.program.body[0]
+  );
+
+  const removeCalls = (calls) => {
+    const jestUnmocks = root.find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: isJestCall,
+        property: {
+          name: name => calls[name],
+        },
+      },
+    });
+    // do these one at a time, then search for more
+    // otherwise the list self-clobbers
+    if (jestUnmocks.size() > 0) {
+      const onlyThisOne = jestUnmocks.paths()[0];
+      onlyThisOne.replace(onlyThisOne.value.callee.object);
+      return 1 + removeCalls(calls);
+    }
+    return 0;
+  };
+
+  const removeDanglingJests = () => {
+    let header;
+    const danglers = root
+      .find(j.Identifier, {name: 'jest'})
+      .filter(path => (
+        path.parentPath.value.type === j.ExpressionStatement.name
+      ));
+    if (danglers.size() > 0) {
+      header = getHeader(danglers.paths()[0]);
+    }
+    danglers.forEach(path => {
+      path.parentPath.replace(null);
+    });
+    restoreHeader(header);
+    return danglers.size();
+  };
+
+  const getHeader = (path) => {
+    if (isRootElement(path)) {
+      return path.parentPath.value.comments;
+    }
+    return null;
+  }
+
+  const restoreHeader = (header) => {
+    const body = root.get(0).node.program.body.filter(a => !!a);
+    if (header && body.length > 0) {
+      if (body[0].comments) {
+        body[0].comments.splice(0, 0, ...header);
+      } else {
+        body[0].comments = header;
+      }
+    }
+  }
+
+
+
+  if (!isGeneratedFile()) {
+    mutations += removeCalls(DISABLE_AUTOMOCK_CALLS);
+    mutations += removeDanglingJests();
+  }
+
+  const printOptions = {
+    quote: 'single',
+    trailingComma: true,
+    wrapColumn: 80,
+  };
+  return mutations > 0 ? root.toSource(printOptions) : null;
+};


### PR DESCRIPTION
This codemod transforms jest test files to remove instances of `.disableAutomock()` while preserving the rest of the function chain (ex. `jest.disableAutomock().mock('abc')` => `jest.mock('abc')`). It also removes any empty `jest;` statements left by the transform and preserves header comments if they would be stripped.