### PR TITLE
Add a codemod to favor object spread over `Object.assign`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ jscodeshift -t js-codemod/transforms/rm-copyProperties.js <file>
 jscodeshift -t js-codemod/transforms/rm-merge.js <file>
 ```
 
+#### `rm-object-assign`
+
+```sh
+jscodeshift -t js-codemod/transforms/rm-object-assign.js <file>
+```
+
 #### `rm-requires`
 
 Removes any requires where the imported value is not referenced. Additionally

--- a/transforms/__testfixtures__/rm-object-assign.input.js
+++ b/transforms/__testfixtures__/rm-object-assign.input.js
@@ -1,0 +1,9 @@
+let x = Object.assign({}, { a: 1 }, { b: 2 });
+
+Object.assign({}, a);
+
+Object.assign({ a: 1 }, b, { c: 3 });
+
+Object.assign(a, b);
+
+Object.assign({}, ...b);

--- a/transforms/__testfixtures__/rm-object-assign.output.js
+++ b/transforms/__testfixtures__/rm-object-assign.output.js
@@ -1,0 +1,18 @@
+let x = {
+  a: 1,
+  b: 2,
+};
+
+({
+  ...a,
+});
+
+({
+  a: 1,
+  ...b,
+  c: 3,
+});
+
+Object.assign(a, b);
+
+Object.assign({}, ...b);

--- a/transforms/__tests__/rm-object-assign-test.js
+++ b/transforms/__tests__/rm-object-assign-test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+const printOptions = { trailingComma: true };
+defineTest(__dirname, 'rm-object-assign', { printOptions });

--- a/transforms/rm-object-assign.js
+++ b/transforms/rm-object-assign.js
@@ -1,0 +1,27 @@
+module.exports = (file, api, options) => {
+  const j = api.jscodeshift;
+  const flatten = array => [].concat(...array);
+  const printOptions = options.printOptions || { quote: 'single' };
+  const root = j(file.source);
+
+  const rmObjectAssignCall = path =>
+    j(path).replaceWith(
+      j.objectExpression(
+        flatten(
+          path.value.arguments.map(
+            a => a.type === 'ObjectExpression' ? a.properties : j.spreadProperty(a)
+          )
+        )
+      )
+    );
+
+  root
+    .find(j.CallExpression, {
+      callee: { object: { name: 'Object' }, property: { name: 'assign' } },
+      arguments: [{ type: 'ObjectExpression' }]
+    })
+    .filter(p => !p.value.arguments.some(a => a.type === 'SpreadElement'))
+    .forEach(rmObjectAssignCall);
+
+  return root.toSource(printOptions);
+};


### PR DESCRIPTION
I originally made this codemod for @doctolib but I think it's worth sharing with the community. Is it the right place to drop it?