### PR TITLE
Add indexof-to-includes transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ jscodeshift -t js-codemod/transforms/arrow-function.js <file>
 
 `--max-width=120`: Try the best it can to keep line lengths under the specified length.
 
+#### `indexof-to-includes`
+
+Transforms code like `foo.indexOf(bar) > -1` to `foo.includes(bar)`.
+
+```sh
+jscodeshift -t js-codemod/transforms/indexof-to-includes.js <file>
+```
+
 #### `invalid-requires`
 
 ```sh

--- a/transforms/__testfixtures__/indexof-to-includes.input.js
+++ b/transforms/__testfixtures__/indexof-to-includes.input.js
@@ -1,0 +1,59 @@
+if (foo.indexOf(bar) >= 0) {
+  // yes
+}
+
+if (!foo.indexOf(bar) >= 0) {
+  // no
+}
+
+if (foo.indexOf(bar) > -1) {
+  // yes
+}
+
+if (foo.indexOf(bar) <= -1) {
+  // no
+}
+
+if (abb.foo.indexOf(bar) <= -1) {
+  // no
+}
+
+if (foo.indexOf(bar) < 0) {
+  // no
+}
+
+if (foo.indexOf(bar) === -1) {
+  // no
+}
+
+if (foo.indexOf(bar) == -1) {
+  // no
+}
+
+if (foo.indexOf(bar) === 0) {
+  // no change
+}
+
+if (foo.indexOf(bar) === 1) {
+  // no change
+}
+
+if (foo.indexOf(bar) === 2) {
+  // no change
+}
+
+if (foo.indexOf(bar) == 0) {
+  // no change
+}
+
+if (foo.indexOf(bar) == 1) {
+  // no change
+}
+
+if (foo.indexOf(bar) == 2) {
+  // no change
+}
+
+if (!bar.includes(foo)) {
+  // no change
+}

--- a/transforms/__testfixtures__/indexof-to-includes.output.js
+++ b/transforms/__testfixtures__/indexof-to-includes.output.js
@@ -1,0 +1,59 @@
+if (foo.includes(bar)) {
+  // yes
+}
+
+if (!foo.includes(bar)) {
+  // no
+}
+
+if (foo.includes(bar)) {
+  // yes
+}
+
+if (!foo.includes(bar)) {
+  // no
+}
+
+if (!abb.foo.includes(bar)) {
+  // no
+}
+
+if (!foo.includes(bar)) {
+  // no
+}
+
+if (!foo.includes(bar)) {
+  // no
+}
+
+if (!foo.includes(bar)) {
+  // no
+}
+
+if (foo.indexOf(bar) === 0) {
+  // no change
+}
+
+if (foo.indexOf(bar) === 1) {
+  // no change
+}
+
+if (foo.indexOf(bar) === 2) {
+  // no change
+}
+
+if (foo.indexOf(bar) == 0) {
+  // no change
+}
+
+if (foo.indexOf(bar) == 1) {
+  // no change
+}
+
+if (foo.indexOf(bar) == 2) {
+  // no change
+}
+
+if (!bar.includes(foo)) {
+  // no change
+}

--- a/transforms/__tests__/indexof-to-includes-test.js
+++ b/transforms/__tests__/indexof-to-includes-test.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+const printOptions = {
+  trailingComma: true,
+};
+
+defineTest(__dirname, 'indexof-to-includes', {printOptions});

--- a/transforms/indexof-to-includes.js
+++ b/transforms/indexof-to-includes.js
@@ -1,0 +1,104 @@
+// Convert code like
+//
+//   foo.indexOf(bar) > -1
+//
+// to
+//
+//   foo.includes(bar)
+
+function isAlreadyNegated(path) {
+  return path.node.left.type === 'UnaryExpression';
+}
+
+function shouldBeNotIncludes(path) {
+  const operator = path.node.operator;
+
+  if (path.node.right.type === 'UnaryExpression') {
+    // negative
+    const value = path.node.right.argument.value;
+
+    if (operator === '===' && value === 1) {
+      return !isAlreadyNegated(path);
+    }
+
+    if (operator === '==' && value === 1) {
+      return !isAlreadyNegated(path);
+    }
+
+    if (operator === '<=' && value === 1) {
+      return !isAlreadyNegated(path);
+    }
+  } else {
+    // not negative
+    const value = path.node.right.value;
+
+    if (operator === '<' && value === 0) {
+      return !isAlreadyNegated(path);
+    }
+  }
+
+  return isAlreadyNegated(path);
+}
+
+export default function transformer(file, api, options) {
+  const j = api.jscodeshift;
+  const printOptions = options.printOptions || { quote: 'single' };
+
+  const root = j(file.source);
+
+  // Find expressions like foo.indexOf() > 0
+  const indexOfs = root
+    .find(j.BinaryExpression)
+    .filter(path => (
+      (
+        path.node.left.type === 'CallExpression'
+        && path.node.left.callee.type === 'MemberExpression'
+        && path.node.left.callee.property.name === 'indexOf'
+      ) || (
+        path.node.left.type === 'UnaryExpression'
+        && path.node.left.argument.type === 'CallExpression'
+        && path.node.left.argument.callee.type === 'MemberExpression'
+        && path.node.left.argument.callee.property.name === 'indexOf'
+      )
+    ))
+    .filter(path => (
+      (
+        // not negative
+        path.node.right.type === 'Literal'
+        && path.node.operator !== '=='
+        && path.node.operator !== '==='
+        && path.node.right.value === 0
+      ) || (
+        // negative
+        path.node.right.type === 'UnaryExpression'
+        && path.node.right.argument.type === 'Literal'
+        && path.node.right.argument.value === 1
+      )
+    ));
+
+  if (!indexOfs.length) {
+    return undefined;
+  }
+
+  indexOfs.forEach((path) => {
+    const callExpression = path.node.left.type === 'UnaryExpression'
+      ? path.node.left.argument
+      : path.node.left;
+
+    let includes = j.callExpression(
+      j.memberExpression(
+        callExpression.callee.object,
+        j.identifier('includes')
+      ),
+      callExpression.arguments
+    );
+
+    if (shouldBeNotIncludes(path)) {
+      includes = j.unaryExpression('!', includes);
+    }
+
+    j(path).replaceWith(includes);
+  });
+
+  return root.toSource(printOptions);
+}


### PR DESCRIPTION
This transforms code like:

```js
foo.indexOf(bar) > -1
```

to

```js
foo.includes(bar)
```