### PR TITLE
add in jest-rm-jasmine-this transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ jscodeshift -t js-codemod/transforms/invalid-requires.js <file>
 jscodeshift -t js-codemod/transforms/jest-update.js <file>
 ```
 
+#### `jest-rm-jasmine-this`
+
+Convert Jasmine-style code using beforeEach`this` properties into Jest-style shared `let` code.
+
 #### `no-vars`
 
 Conservatively converts `var` to `const` or `let`.

--- a/transforms/__testfixtures__/jest-rm-jasmine-this.input.js
+++ b/transforms/__testfixtures__/jest-rm-jasmine-this.input.js
@@ -1,0 +1,15 @@
+describe("jest-rm-jasmine-this transform", function() {
+  beforeEach(function() {
+    this.x = 42
+    this.y = this.x * 2
+  });
+
+  it("detects assignments in beforeEach", function() {
+    expect(this.x).toEqual(42);
+  })
+
+  it("can use re-assigned variables", function() {
+    this.y = this.y / 2
+    expect(this.x).toEqual(42);
+  })
+})

--- a/transforms/__testfixtures__/jest-rm-jasmine-this.output.js
+++ b/transforms/__testfixtures__/jest-rm-jasmine-this.output.js
@@ -1,0 +1,16 @@
+describe("jest-rm-jasmine-this transform", function() {
+  let x, y;
+  beforeEach(function() {
+    x = 42
+    y = x * 2
+  });
+
+  it("detects assignments in beforeEach", function() {
+    expect(x).toEqual(42);
+  })
+
+  it("can use re-assigned variables", function() {
+    y = y / 2
+    expect(x).toEqual(42);
+  })
+})

--- a/transforms/__tests__/jest-rm-jasmine-this-test.js
+++ b/transforms/__tests__/jest-rm-jasmine-this-test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+defineTest(__dirname, 'jest-rm-jasmine-this');

--- a/transforms/jest-rm-jasmine-this.js
+++ b/transforms/jest-rm-jasmine-this.js
@@ -1,0 +1,75 @@
+/**
+ * Convert Jasmine-style code to Jest code.
+ *
+ * Background: Jasmine recommended using a `this` to provide context between
+ * `beforeEach` blocks and specs, but Jest removed this functionality, as noted
+ * here:
+ * https://github.com/facebook/jest/pull/3957
+ *
+ * This script pulls out `this.` declarations from `beforeEach` blocks and
+ * puts them into shared `let`s.
+ *
+ * There are cases it doesn't handle:
+ * * tests that establish different `this` contexts for other purposes will be
+ *   incorrectly patched
+ * * `this` usages within specs without `beforeEach` references will break
+ */
+export default function transformer (file, api) {
+  const j    = api.jscodeshift
+  const b    = j.types.builders
+  const root = j(file.source)
+
+  // Build `let` statement based on each `beforeEach` block.
+  j.types.visit(root, {
+    visitFunction: function (path) {
+      if (!path.parent.value.callee) return this.traverse(path)
+
+      const fnName = path.parent.value.callee.name,
+            type   = path.parent.value.type
+      if (fnName === 'beforeEach' && type == 'CallExpression') {
+
+        const thisAssignmentExpressions = root.find(j.AssignmentExpression, {
+          left: {
+            type  : 'MemberExpression',
+            object: { type: 'ThisExpression' }
+          }
+        })
+
+        let varNames = []
+        thisAssignmentExpressions
+          .filter(ae => {
+            let pp = ae.parentPath
+            while (pp && pp.value !== path.value) pp = pp.parentPath
+            return !!pp
+          })
+          .forEach(ae => {
+            varNames.push(ae.value.left.property.name)
+          })
+        varNames = Array.from(new Set(varNames)) // .uniq
+
+        if (varNames.length > 0) {
+          const letDecl = b.variableDeclaration('let', varNames.map(v =>
+            b.variableDeclarator(j.identifier(v), null)))
+          path.parent.parentPath.insertBefore(letDecl)
+        }
+        return false
+
+      } else
+        return this.traverse(path)
+    }
+  })
+
+
+  // Convert all the `this.` to reference above `let` variables.
+  const memberExpressions = root.find(j.Node, {
+    type  : 'MemberExpression',
+    object: {
+      type: 'ThisExpression'
+    }
+  })
+  memberExpressions.forEach(memberExpression => {
+    memberExpression.replace(j.identifier(memberExpression.value.property.name))
+  })
+
+  return root.toSource()
+}


### PR DESCRIPTION
This rewrites Jest tests that use the recommended Jasmine syntax to use Jest's new local `let` variable version. Details here:
https://github.com/facebook/jest/pull/3957
