### PR TITLE
arrow-function-arguments: filter identifiers in member expressions

### DIFF
--- a/transforms/__testfixtures__/arrow-function-arguments.input.js
+++ b/transforms/__testfixtures__/arrow-function-arguments.input.js
@@ -26,3 +26,5 @@ var fn4 = function(a, b, c) {
 };
 
 var fn5 = (a, ...b) => arguments;
+
+var fn7 = (ref) => console.log(ref.arguments);

--- a/transforms/__testfixtures__/arrow-function-arguments.output.js
+++ b/transforms/__testfixtures__/arrow-function-arguments.output.js
@@ -26,3 +26,5 @@ var fn4 = function(a, b, c) {
 };
 
 var fn5 = (a, ...b) => [a, ...b];
+
+var fn7 = (ref) => console.log(ref.arguments);

--- a/transforms/arrow-function-arguments.js
+++ b/transforms/arrow-function-arguments.js
@@ -14,6 +14,8 @@ module.exports = (file, api, options) => {
       fn.generator
     );
 
+  const filterMemberExpressions = path => path.parent.value.type !== "MemberExpression"
+
   const filterArrowFunctions = path => {
     while (path.parent) {
       switch (path.value.type) {
@@ -71,6 +73,7 @@ module.exports = (file, api, options) => {
 
   const didTransform = root
     .find(j.Identifier, {name: ARGUMENTS})
+    .filter(filterMemberExpressions)
     .filter(filterArrowFunctions)
     .forEach(updateArgumentsCalls)
     .size() > 0;


### PR DESCRIPTION
Otherwise it transforms to:
 var fn7 = (ref, ...args) => console.log(ref.[ref, ...args]);