### PR TITLE
Do not transform functions using arguments object

### DIFF
--- a/transforms/arrow-function.js
+++ b/transforms/arrow-function.js
@@ -89,8 +89,9 @@ module.exports = (file, api, options) => {
       const isArgument = path.parentPath.name === 'arguments' && path.parentPath.value.indexOf(path.value) > -1;
       const noThis = j(path).find(j.ThisExpression).size() == 0;
       const notNamed = !path.value.id || !path.value.id.name;
+      const noArgumentsRef = j(path).find(j.Identifier).filter(idPath => idPath.node.name === 'arguments' && idPath.scope.depth === path.get('body').scope.depth).size() === 0;
 
-      return isArgument && noThis && notNamed;
+      return isArgument && noThis && notNamed && noArgumentsRef;
     })
     .forEach(path =>
       j(path).replaceWith(


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#No_binding_of_arguments
"Arrow functions do not have their own arguments object."

Therefore
```
function () { console.log(arguments); }
```
is not the same as
```
() => { console.log(arguments); }
```