### PR TITLE
Don't transform generator functions to arrow

### DIFF
--- a/transforms/__testfixtures__/arrow-function.input.js
+++ b/transforms/__testfixtures__/arrow-function.input.js
@@ -88,3 +88,11 @@ foo(function baz_prototype() {
 });
 
 baz_prototype.prototype = {};
+
+var generatorFunc = function* () {
+  console.log('I shall not be transformed!');
+}.bind(this);
+
+foo(function* () {
+  console.log('I shall not be transformed!');
+});

--- a/transforms/__testfixtures__/arrow-function.output.js
+++ b/transforms/__testfixtures__/arrow-function.output.js
@@ -69,3 +69,11 @@ foo(function baz_prototype() {
 });
 
 baz_prototype.prototype = {};
+
+var generatorFunc = function* () {
+  console.log('I shall not be transformed!');
+}.bind(this);
+
+foo(function* () {
+  console.log('I shall not be transformed!');
+});

--- a/transforms/arrow-function.js
+++ b/transforms/arrow-function.js
@@ -60,6 +60,7 @@ module.exports = (file, api, options) => {
         type: 'MemberExpression',
         object: {
           type: 'FunctionExpression',
+          generator: false,
         },
         property: {
           type: 'Identifier',
@@ -89,7 +90,9 @@ module.exports = (file, api, options) => {
     .size() > 0;
 
   const replacedCallbacks = root
-    .find(j.FunctionExpression)
+    .find(j.FunctionExpression, {
+      generator: false,
+    })
     .filter(path => {
       const isArgument = path.parentPath.name === 'arguments' && path.parentPath.value.indexOf(path.value) > -1;
       const noThis = j(path).find(j.ThisExpression).size() == 0;


### PR DESCRIPTION
I noticed that anonymous generator functions are getting transformed to arrow functions, with the output resulting in a different type of function altogether. An example of the input & output can be seen [here](https://astexplorer.net/#/gist/fcf7ab3025c4857a5879fef90df56504/b6111c138a5da7e25bab23111fa398bcdacdcf6a).

This PR changes the arrow-function.js codemod to transform non-generator functions only.