### PR TITLE
Fix relativ path usage in imports readme

### DIFF
--- a/extensions/imports/README.md
+++ b/extensions/imports/README.md
@@ -22,10 +22,10 @@ module.exports = function(fileInfo, api) {
 
 Different configs will be needed based on your code style, this extension comes
 with two default configs:
- - [Basic commonJS style](config/CJSBasicRequireConfig.js), all requires in one
+ - [Basic commonJS style](./config/CJSBasicRequireConfig.js), all requires in one
 block.
- - [Facebook style](config/FBRequireConfig.js), requires are split by the case
-of the module's name.
+ - [Facebook style](./config/FBRequireConfig.js), requires are split by the case
+of the module's name
 
 You can also provide your own custom config.
 


### PR DESCRIPTION
Link to `Basic commonJS style` and `Facebook style` was not relative, and therefore did not work.