### PR TITLE
Ignore coerced numbers

### DIFF
--- a/transforms/unquote-properties.js
+++ b/transforms/unquote-properties.js
@@ -8,6 +8,11 @@ module.exports = (file, api, options) => {
   const root = j(file.source);
 
   const isValidIdentifierNameForProperty = (name) => {
+    
+    if (/^0[xbo]?\d+$/.test(name)) {
+      return false;
+    }
+    
     try {
       new Function(`({${name}: 1})`)(); //eslint-disable-line no-new-func
     } catch (e) {


### PR DESCRIPTION
Strings that coerce into number representations different from themselves (e.g. `'0x04'`, `'0o42'`, `'0b100'`, `'08'`) should be ignored.